### PR TITLE
Implement aggregate functions and HAVING clause in visual query editor

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -118,36 +118,86 @@ class Table
         } // for visual query
         else {
 
-            $query = 'SELECT ';
+            $select_parts = [];
 
-            // find out which fields to SELECT
-            if (array_key_exists('fields', $_POST) && count($_POST['fields'])) {
-                $total = count($_POST['fields']);
-
-                $duplicateNameFields = array();
-                $counter = 0;
-
+            // Process non-aggregated fields
+            if (!empty($_POST['fields'])) {
+                $duplicateNameFields = []; // To handle potential duplicate field names if selected multiple times (though less likely with table.field format)
                 foreach ($_POST['fields'] as $value) {
-                    $counter ++;
-
                     if ($value) {
-                        $duplicateNameFields[] = $value;
-
-                        // apply AS keyword for same field names from different tables
-                        if (in_array($value, $duplicateNameFields)) {
-                            $fieldArray = explode('.', $value);
-                            $tableName = $fieldArray[0];
-                            $fieldName = $fieldArray[1];
-                            $value = $value . ' AS ' . $tableName . '_' . $fieldName;
+                        // Basic protection for field names, assuming 'table.field' format
+                        // More robust quoting might be needed if arbitrary values are allowed.
+                        // The current UI generates table.field, so direct usage is mostly safe.
+                        // For aliasing to avoid conflicts if the same simple field is selected multiple times (e.g. from different joins before full qualification was implemented)
+                        // This logic might be less critical if all fields are fully qualified (table.field)
+                        $baseValue = $value;
+                        if (in_array($baseValue, $duplicateNameFields)) {
+                            $fieldArray = explode('.', $baseValue);
+                            if (count($fieldArray) === 2) {
+                                $value = $baseValue . ' AS ' . $fieldArray[0] . '_' . $fieldArray[1];
+                            }
+                            // If it's already aliased or not in table.field format, use as is or consider more complex aliasing
                         }
-
-                        if ($total === $counter) {
-                            $query .= $value;
-                        } else {
-                            $query .= $value . ', ';
-                        }
+                        $duplicateNameFields[] = $baseValue;
+                        $select_parts[] = $value;
                     }
                 }
+            }
+
+            // Process aggregated fields
+            if (!empty($_POST['agg_field']) && is_array($_POST['agg_field'])) {
+                foreach ($_POST['agg_field'] as $key => $field_name) {
+                    if (empty($field_name) || empty($_POST['agg_func'][$key])) {
+                        continue; // Skip if field name or function is missing
+                    }
+
+                    $func = strtoupper($_POST['agg_func'][$key]);
+                    $alias = $_POST['agg_alias'][$key] ?? '';
+
+                    // Basic validation for aggregate functions
+                    $allowed_funcs = ['COUNT', 'SUM', 'AVG', 'MIN', 'MAX'];
+                    if (!in_array($func, $allowed_funcs)) {
+                        // Potentially log an error or skip
+                        continue;
+                    }
+
+                    // Field name is expected to be table.field - quote it carefully if needed
+                    // For now, assuming $field_name is like 'tablename.fieldname'
+                    // Proper quoting: `table`.`field`
+                    $field_parts = explode('.', $field_name, 2);
+                    $quoted_field_name = $field_name; // Default to as-is if not 'table.field'
+                    if (count($field_parts) == 2) {
+                         // Basic quoting, can be improved for robustness
+                        $quoted_field_name = "`" . str_replace("`", "``", $field_parts[0]) . "`.`" . str_replace("`", "``", $field_parts[1]) . "`";
+                    } else {
+                        // If it's a single word, assume it's a field from the primary table or already quoted
+                        $quoted_field_name = "`" . str_replace("`", "``", $field_name) . "`";
+                    }
+
+
+                    $agg_string = $func . '(' . $quoted_field_name . ')';
+
+                    if (!empty($alias)) {
+                        // Sanitize alias: basic, allow alphanumeric and underscores
+                        $alias = preg_replace('/[^a-zA-Z0-9_]/', '', $alias);
+                        if (!empty($alias)) {
+                            $agg_string .= ' AS `' . $alias . '`';
+                        } else { // if alias became empty after sanitizing, generate default
+                            $default_alias = strtolower($func . '_' . preg_replace('/[^a-zA-Z0-9_]/', '', $field_parts[1] ?? $field_name));
+                            $agg_string .= ' AS `' . $default_alias . '`';
+                        }
+                    } else {
+                        $default_alias = strtolower($func . '_' . preg_replace('/[^a-zA-Z0-9_]/', '', $field_parts[1] ?? $field_name));
+                        $agg_string .= ' AS `' . $default_alias . '`';
+                    }
+                    $select_parts[] = $agg_string;
+                }
+            }
+
+            if (empty($select_parts)) {
+                $query = 'SELECT *';
+            } else {
+                $query = 'SELECT ' . implode(', ', $select_parts);
             }
 
             $query .= ' FROM `' . Flight::get('lastSegment') . '`';
@@ -198,6 +248,49 @@ class Table
                 $query .= ' GROUP BY ';
                 $query .= implode(', ', $_POST['groupfields']);
             }
+
+            // find out which fields/conditions to put in HAVING clause
+            if (!empty($_POST['hfname']) && is_array($_POST['hfname'])) {
+                $having_conditions = [];
+                $first_having_condition = true;
+                foreach ($_POST['hfname'] as $key => $hfname_val) {
+                    if (!empty($hfname_val) && isset($_POST['hfvalue'][$key]) && $_POST['hfvalue'][$key] !== '') {
+                        $hcondition_string = '';
+                        if (!$first_having_condition && isset($_POST['htype'][$key])) {
+                            $hcondition_string .= ' ' . $_POST['htype'][$key] . ' ';
+                        }
+                        $first_having_condition = false;
+
+                        // Quote field name/alias for HAVING. Aliases should not be table.field
+                        // If hfname_val contains '.', it's likely a table.field from GROUP BY, otherwise an alias.
+                        // For safety, we'll assume aliases do not contain '.' and fields from GROUP BY might.
+                        // SQL standard allows aliases from SELECT to be used in HAVING.
+                        // If it's an alias, it shouldn't be `table`.`alias`. Just `alias`.
+                        if (strpos($hfname_val, '.') === false) {
+                             // Likely an alias, quote it simply
+                            $hcondition_string .= '`' . str_replace("`", "``", $hfname_val) . '`';
+                        } else {
+                            // Likely a table.field from GROUP BY. Quote accordingly.
+                            $hfield_parts = explode('.', $hfname_val, 2);
+                            if (count($hfield_parts) == 2) {
+                                $hcondition_string .= "`" . str_replace("`", "``", $hfield_parts[0]) . "`.`" . str_replace("`", "``", $hfield_parts[1]) . "`";
+                            } else { // Fallback for non-standard field name
+                                $hcondition_string .= "`" . str_replace("`", "``", $hfname_val) . "`";
+                            }
+                        }
+
+                        // The hfvalue is expected to contain operator and value, e.g., "> 100" or "= 'text'"
+                        // This part needs to be robust. For now, direct concatenation.
+                        // TODO: Separate operator and value in UI and process them safely here.
+                        $hcondition_string .= ' ' . $_POST['hfvalue'][$key];
+                        $having_conditions[] = $hcondition_string;
+                    }
+                }
+                if (!empty($having_conditions)) {
+                    $query .= ' HAVING ' . implode('', $having_conditions); // Conditions already include AND/OR
+                }
+            }
+
 
             // find out ORDER BY fields
             if (array_key_exists('orderfields', $_POST) && count($_POST['orderfields'])) {

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -111,13 +111,25 @@ $fields = $fields ?? [];
                     </div>
 
                     <div class="form-group">
-    <label class="control-label" for="fields">Select Fields</label>
+    <label class="control-label" for="fields">Select Non-Aggregated Fields</label>
     <div class="controls">
         <select name="fields[]" multiple="multiple" class="form-control fields" style="width: 100%;">
             <?php echo $fields; ?>
         </select>
     </div>
 </div>
+
+                    <div class="form-group">
+                        <hr/>
+                        <label class="control-label">Aggregated Fields</label>
+                        <button style="margin-bottom: 10px !important;" type="button" id="btnAddAggregateField" class="btn btn-info" rel="hover_popover" data-content="Add SUM, COUNT, AVG etc.">
+                            <i class="glyphicon glyphicon-plus-sign"></i> Add Aggregate Field
+                        </button>
+                        <div id="aggregateFieldsContainer">
+                            <!-- Cloned aggregate fields will be inserted here -->
+                        </div>
+                        <hr/>
+                    </div>
 
                     <div class="form-group">
                         <button style="margin-bottom: 10px !important;" type="button" id="btnAddWhere" class="btn btn-primary" rel="hover_popover" data-content="Add WHERE clause conditions">
@@ -166,10 +178,22 @@ $fields = $fields ?? [];
                             &nbsp;
                         </div>
                         <div class="controls pull-left">
-                            <select name="groupfields[]" id="groupfields" multiple class="groupfields form-control" style="width: 400px;">
+                            <select name="groupfields[]" id="groupfields" multiple class="groupfields form-control fields" style="width: 400px;">
                                 <?php echo $fields; ?>
                             </select>
                         </div>
+                    </div>
+
+                    <div class="form-group">
+                        <hr/>
+                        <label class="control-label">Having Conditions</label>
+                        <button style="margin-bottom: 10px !important;" type="button" id="btnAddHavingCondition" class="btn btn-warning" rel="hover_popover" data-content="Add HAVING clause conditions (filters on aggregate values)">
+                            <i class="glyphicon glyphicon-filter"></i> Add Having Condition
+                        </button>
+                        <div id="havingConditionsContainer">
+                            <!-- Cloned having conditions will be inserted here -->
+                        </div>
+                        <hr/>
                     </div>
 
                     <div class="form-group">
@@ -252,6 +276,36 @@ $fields = $fields ?? [];
     <div class="clearfix"></div>
 </div>
 
+<div id="fieldCloneHaving" class="parent" style="display: none; margin: 3px;">
+    <div class="pull-left">
+        <a href="#" class="remove"><i class="glyphicon glyphicon-trash glyphicon-2x" style="margin-top: 5px;"></i></a>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <select name="htype[]" class="form-control" style="width: 70px;">
+            <option value="AND">AND</option>
+            <option value="OR">OR</option>
+        </select>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <select name="hfname[]" placeholder="Field Name / Alias" class="hfname form-control fields" style="width: 250px;">
+            <?php echo $fields; ?>
+        </select>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <input type="text" name="hfvalue[]" placeholder="Operator + Value eg > 100" class="form-control" style="height: 28px; width: 250px;">
+    </div>
+    <div class="clearfix"></div>
+</div>
+
 <div id="fieldCloneTable" class="parent" style="display: none; margin: 3px;">
     <div class="pull-left">
         <a href="#" class="remove removeme"><i class="glyphicon glyphicon-trash glyphicon-2x" style="margin-top: 5px;"></i></a>
@@ -288,10 +342,44 @@ $fields = $fields ?? [];
         &nbsp;
     </div>
     <div class="pull-left">
-        <select name="joinfieldp[]" class="joinfieldmain form-control" style="width: 160px;">
+        <select name="joinfieldp[]" class="joinfieldmain form-control fields" style="width: 160px;">
             <option value="">Joining with Field</option>
-            <?= $fields ?? '' ?>
+            <?php echo $fields ?? '' ?>
         </select>
+    </div>
+    <div class="clearfix"></div>
+</div>
+
+<div id="fieldCloneAggregate" class="parent" style="display: none; margin: 10px 0;">
+    <div class="pull-left">
+        <a href="#" class="remove"><i class="glyphicon glyphicon-trash glyphicon-2x" style="margin-top: 5px;"></i></a>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <select name="agg_field[]" class="form-control fields agg_field" style="width: 200px;" data-placeholder="Select Field">
+            <?php echo $fields; ?>
+        </select>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <select name="agg_func[]" class="form-control agg_func" style="width: 120px;">
+            <option value="">None</option>
+            <option value="COUNT">COUNT</option>
+            <option value="SUM">SUM</option>
+            <option value="AVG">AVG</option>
+            <option value="MIN">MIN</option>
+            <option value="MAX">MAX</option>
+        </select>
+    </div>
+    <div class="pull-left" style="margin: 3px;">
+        &nbsp;
+    </div>
+    <div class="pull-left">
+        <input type="text" name="agg_alias[]" placeholder="Alias (optional)" class="form-control agg_alias" style="height: 28px; width: 180px;">
     </div>
     <div class="clearfix"></div>
 </div>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -64,6 +64,129 @@ $('#btnAddWhere').click(function () {
     $clone.find('select').select2();
 });
 
+// add aggregate field for visual query
+$('#btnAddAggregateField').click(function () {
+    var $clone = $('#fieldCloneAggregate').clone().removeAttr('id'); // clone and remove id to avoid duplicates
+    $('#aggregateFieldsContainer').append($clone);
+    $clone.find('.agg_field').select2({ placeholder: 'Select Field', allowClear: true }); // Initialize select2 for the field selection
+    // No need to initialize select2 for agg_func unless specific styling/features are needed for it.
+    $clone.slideDown('fast');
+    updateHavingFieldNameOptions(); // Update HAVING field options when a new aggregate is added
+});
+
+// add Having condition for visual query
+$('#btnAddHavingCondition').click(function () {
+    var $clone = $('#fieldCloneHaving').clone().removeAttr('id');
+    $('#havingConditionsContainer').append($clone);
+    // Initialize select2 for the hfname dropdown, it will be populated by updateHavingFieldNameOptions
+    $clone.find('.hfname').select2({ placeholder: 'Select Field/Alias', allowClear: true });
+    $clone.slideDown('fast');
+    updateHavingFieldNameOptions(); // Ensure new HAVING rows get the correct options
+});
+
+// When aggregate alias or group by fields change, update HAVING field name options
+$('body').on('change', '.agg_alias, .groupfields', function() {
+    updateHavingFieldNameOptions();
+});
+
+
+function updateHavingFieldNameOptions() {
+    var options = [];
+    var existingOptions = {}; // To avoid duplicate options
+
+    // Get options from original fields (table.column)
+    // This re-uses the logic from addTablesToDropdown by fetching the current content of a 'fields' class select
+    // and adapting it. This is a bit of a workaround. A cleaner way might be to have a dedicated source for these options.
+    var generalFieldsHtml = $('select.fields').first().html(); // Get HTML of options from a representative 'fields' select
+    if (generalFieldsHtml) {
+        $(generalFieldsHtml).filter('optgroup').each(function() {
+            var optgroupLabel = $(this).attr('label');
+            var groupOptions = [];
+            $(this).find('option').each(function() {
+                var val = $(this).val();
+                var text = $(this).text();
+                if (!existingOptions[val]) {
+                    groupOptions.push({ val: val, text: text });
+                    existingOptions[val] = true;
+                }
+            });
+            if (groupOptions.length > 0) {
+                options.push({ label: optgroupLabel, options: groupOptions });
+            }
+        });
+         $(generalFieldsHtml).filter('option').each(function() {
+            var val = $(this).val();
+            var text = $(this).text();
+            if (!existingOptions[val]) {
+                options.push({ val: val, text: text }); // Add non-optgrouped options
+                existingOptions[val] = true;
+            }
+        });
+    }
+
+
+    // Get aliases from aggregated fields
+    $('#aggregateFieldsContainer .parent').each(function() {
+        var alias = $(this).find('.agg_alias').val();
+        var field = $(this).find('.agg_field').val();
+        var func = $(this).find('.agg_func').val();
+
+        if (func && field) { // Only consider if function and field are selected
+            var val = alias;
+            if (!val) { // Generate default alias if not provided by user
+                val = func.toLowerCase() + '_' + (field.includes('.') ? field.split('.')[1] : field) ;
+            }
+            var text = alias ? alias + ' (Alias)' : val + ' (Auto-Alias)';
+            if (val && !existingOptions[val]) {
+                options.push({ val: val, text: text, isAlias: true });
+                existingOptions[val] = true;
+            }
+        }
+    });
+
+    // Get fields from GROUP BY clause
+    $('select.groupfields').find('option:selected').each(function() {
+        var val = $(this).val();
+        var text = $(this).text() + ' (Group By)';
+        if (val && !existingOptions[val]) {
+            options.push({ val: val, text: text, isGroupBy: true });
+            existingOptions[val] = true;
+        }
+    });
+
+    var $hfnameSelects = $('select.hfname');
+    var newHtml = '<option value=""></option>'; // Add a blank option for placeholder
+
+    // Build HTML for options, handling optgroups if present in the initial set
+    options.forEach(function(opt) {
+        if (opt.label) { // This is an optgroup
+            newHtml += '<optgroup label="' + opt.label + '">';
+            opt.options.forEach(function(innerOpt) {
+                newHtml += '<option value="' + innerOpt.val + '">' + innerOpt.text + '</option>';
+            });
+            newHtml += '</optgroup>';
+        } else if (opt.isAlias) {
+             newHtml += '<option value="' + opt.val + '">' + opt.text + '</option>';
+        } else if (opt.isGroupBy) {
+             newHtml += '<option value="' + opt.val + '">' + opt.text + '</option>';
+        } else { // These are general fields that might not be in an optgroup
+            newHtml += '<option value="' + opt.val + '">' + opt.text + '</option>';
+        }
+    });
+
+
+    $hfnameSelects.each(function() {
+        var $select = $(this);
+        var currentValue = $select.val(); // Preserve selected value if possible
+        $select.html(newHtml);
+        if (currentValue && $select.find('option[value="' + currentValue + '"]').length > 0) {
+            $select.val(currentValue);
+        }
+        $select.trigger('change.select2'); // Notify select2 of update
+    });
+}
+
+
 // add order by clause for visual query
 $('#btnOrderby').click(function () {
     $('#orderby').slideDown('fast');


### PR DESCRIPTION
Part 1 of visual query editor enhancement.

Features added:
- UI for selecting non-aggregated fields.
- UI for adding/removing aggregated fields (field, function, alias).
- UI for adding/removing HAVING clause conditions (field/alias, operator+value).
- JavaScript logic to manage the new UI elements, including select2 initialization and dynamic population of HAVING field dropdowns with aggregate aliases and GROUP BY fields.
- Server-side PHP logic in Table controller to:
    - Construct SELECT clause with both non-aggregated and aggregated fields, including alias handling.
    - Construct HAVING clause based on user input, with basic quoting for field names and aliases.

Known simplifications/TODOs for later stages:
- Operator and value parsing in WHERE and HAVING conditions needs to be more robust (currently operator+value are a single string).
- Unify client-side and server-side default alias generation logic.