### PR TITLE
Refine autoloader logic for Presenter class

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -33,9 +33,9 @@ function autoloadClass($className) {
 function autoloadPresenter($className) {
 	if (false !== strpos($className, 'flight')) return;
 
-    // Preserve original class name for filename lookup (assuming Presenters also follow PascalCase)
-    $originalClassName = $className;
-    $filename = "app/presenters/" . $originalClassName . ".php";
+    // Revert to lowercase for presenter filename lookup as 'presenter.php' is lowercase
+	$lowercaseClassName = strtolower($className);
+    $filename = "app/presenters/" . $lowercaseClassName . ".php";
 	
     if (is_readable($filename)) {
         require $filename;


### PR DESCRIPTION
Reverts the `autoloadPresenter` function to use lowercase for filename lookup. This is necessary because the base presenter file is named `presenter.php` (lowercase), while the class is likely invoked as `Presenter`.

The previous commit correctly fixed `autoloadClass` for `SqlFormatter.php` by preserving PascalCase. This commit adjusts `autoloadPresenter` to handle its specific lowercase file naming convention.

The `autoloadController` remains unchanged (uses lowercase).