### PR TITLE
Add feature to delete saved queries

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -136,4 +136,43 @@ class Ajax
 
         echo json_encode($response);
     }
+
+    public static function deleteQuery()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred while deleting the query.'];
+
+        if (empty($_POST['query_id']) || !is_numeric($_POST['query_id'])) {
+            $response['message'] = 'Invalid Query ID provided.';
+            echo json_encode($response);
+            return;
+        }
+
+        $query_id = $_POST['query_id'];
+
+        try {
+            $query_to_delete = ORM::for_table('saved_queries')->find_one($query_id);
+
+            if ($query_to_delete) {
+                if ($query_to_delete->delete()) {
+                    $response['status'] = 'success';
+                    $response['message'] = 'Query deleted successfully.';
+                } else {
+                    $response['message'] = 'Failed to delete query from the database.';
+                }
+            } else {
+                $response['message'] = 'Query not found or already deleted.';
+                // Optionally set status to success if not finding it means it's "deleted" from user perspective
+                // For now, keeping it as an error if not found.
+            }
+        } catch (PDOException $e) {
+            error_log("Error deleting query: " . $e->getMessage());
+            $response['message'] = 'Database error: Could not delete the query. ' . $e->getMessage();
+        } catch (Exception $e) {
+            error_log("General error deleting query: " . $e->getMessage());
+            $response['message'] = 'An unexpected error occurred: ' . $e->getMessage();
+        }
+
+        echo json_encode($response);
+    }
 }

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -160,6 +160,75 @@ $('body').on('click', '.btn-run-saved-query', function() {
     }
 });
 
+// --- Delete Saved Query Functionality ---
+// Delegated click handler for the delete button on a saved query item
+$('body').on('click', '.btn-delete-saved-query', function() {
+    var queryId = $(this).data('query-id');
+    var queryName = $(this).data('query-name'); // Get the name for the confirmation message
+
+    // Store the queryId on the confirmation modal's delete button
+    // This is one way to pass the ID to the actual delete action
+    $('#modal-delete-confirm').data('query-id-to-delete', queryId);
+
+    // Customize confirmation message (optional, if the modal can display dynamic text)
+    // For now, relying on the generic message in #modal-delete-confirm
+    // If #modal-delete-confirm had a <span id="item-to-delete-name"></span>, you could do:
+    // $('#item-to-delete-name').text(queryName || 'this item');
+
+    $('#modal-delete-confirm').modal('show');
+});
+
+// Click handler for the final delete confirmation button inside #modal-delete-confirm
+// Assumes #modal-delete-confirm has a button with class .btnDelete (as per modals.php)
+$('#modal-delete-confirm').on('click', '.btnDelete', function() {
+    var queryIdToDelete = $('#modal-delete-confirm').data('query-id-to-delete');
+
+    if (!queryIdToDelete) {
+        $.jGrowl('Could not determine which query to delete. Please try again.', { header: 'Error', theme: 'error' });
+        $('#modal-delete-confirm').modal('hide');
+        return;
+    }
+
+    var $thisButton = $(this); // The .btnDelete inside the confirmation modal
+    $thisButton.prop('disabled', true); // Disable while processing
+
+    $.ajax({
+        url: base + '/ajax/deleteQuery',
+        type: 'POST',
+        data: { query_id: queryIdToDelete },
+        dataType: 'json',
+        success: function(response) {
+            if (response.status === 'success') {
+                $.jGrowl(response.message || 'Query deleted successfully!', { header: 'Success', theme: 'success' });
+
+                // Remove the item from the list in #modal-list-queries
+                $('#savedQueriesListContainer li[data-query-list-id="' + queryIdToDelete + '"]').fadeOut(function() {
+                    $(this).remove();
+                    if ($('#savedQueriesListContainer li').length === 0) {
+                        $('#savedQueriesListContainer').html('<p class="text-muted">No saved queries found.</p>');
+                    }
+                });
+
+                // Remove from cache
+                savedQueriesCache = savedQueriesCache.filter(function(query) {
+                    return query.id != queryIdToDelete;
+                });
+
+            } else {
+                $.jGrowl(response.message || 'Could not delete the query.', { header: 'Error', theme: 'error' });
+            }
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $.jGrowl('AJAX Error: Could not delete query. ' + textStatus, { header: 'Error', theme: 'error' });
+        },
+        complete: function() {
+            $('#modal-delete-confirm').modal('hide');
+            $thisButton.prop('disabled', false); // Re-enable button
+            $('#modal-delete-confirm').removeData('query-id-to-delete'); // Clean up
+        }
+    });
+});
+
 
 function updateHavingFieldNameOptions() {
     var options = [];
@@ -413,11 +482,12 @@ function fetchAndDisplaySavedQueries() {
                 savedQueriesCache = response.queries; // Cache the queries
                 var listHtml = '<ul class="list-group">';
                 $.each(response.queries, function(index, query) {
-                    listHtml += '<li class="list-group-item d-flex justify-content-between align-items-center">';
+                    listHtml += '<li class="list-group-item d-flex justify-content-between align-items-center" data-query-list-id="' + query.id + '">'; // Add data-query-list-id to li for easy removal
                     listHtml += escapeHtml(query.query_name); // Display query name
+                    listHtml += '<div>'; // Group buttons
                     listHtml += '<button type="button" class="btn btn-primary btn-xs btn-run-saved-query" data-query-id="' + query.id + '" style="margin-left: 10px;"><i class="fa fa-play"></i> Run</button>';
-                    // Future: Add edit/delete buttons here, using query.id
-                    // listHtml += '<span class="badge badge-primary badge-pill">' + query.id + '</span>'; // Example badge
+                    listHtml += '<button type="button" class="btn btn-danger btn-xs btn-delete-saved-query" data-query-id="' + query.id + '" data-query-name="' + escapeHtml(query.query_name) + '" style="margin-left: 5px;"><i class="fa fa-trash-o"></i> Delete</button>';
+                    listHtml += '</div>';
                     listHtml += '</li>';
                 });
                 listHtml += '</ul>';


### PR DESCRIPTION
This commit implements the functionality for users to delete their previously saved queries.

Key changes:

1.  **UI Update (`assets/js/custom.js`):**
    *   Modified `fetchAndDisplaySavedQueries` to add a "Delete" button
      (with a trash icon) to each item in the saved queries list.
    *   The delete button stores the query ID and name as data attributes.
    *   The list item `<li>` also gets a data attribute for its query ID
      to facilitate easy removal from the DOM.

2.  **JavaScript for Deletion Workflow (`assets/js/custom.js`):**
    *   Added a delegated event listener for the new "Delete" buttons.
    *   Clicking "Delete" retrieves the query ID and shows the existing
      generic confirmation modal (`#modal-delete-confirm`), passing the
      ID by storing it on the modal.
    *   Added an event listener for the confirmation action within the
      delete modal.
    *   On confirmation, an AJAX POST request is made to `/ajax/deleteQuery`
      with the query ID.
    *   Handles the AJAX response by:
        *   Showing success/error messages using jGrowl.
        *   Removing the deleted query's item from the UI list.
        *   Removing the deleted query from the `savedQueriesCache`.
        *   Closing the confirmation modal and resetting its state.

3.  **Server-Side Endpoint (`app/controllers/ajax.php`):**
    *   Added a new `deleteQuery()` method to the `Ajax` controller.
    *   This method is mapped via the existing dynamic POST router for
      `/ajax/deleteQuery`.
    *   It expects `query_id` from the POST data, validates it.
    *   Uses Idiorm ORM to find and delete the query from the
      `saved_queries` table.
    *   Returns a JSON response indicating the success or failure of the
      operation, including error handling for database issues or if the
      query is not found.
    *   Error logging is included for server-side exceptions.