### PR TITLE
Refactor: Display saved queries on dashboard instead of modal

### DIFF
--- a/app/controllers/dashboard.php
+++ b/app/controllers/dashboard.php
@@ -10,11 +10,30 @@ class Dashboard
         // Checks whether or not user is logged in
         self::checkLogin();
 
+        $saved_queries = [];
+        try {
+            $queries = ORM::for_table('saved_queries')
+                            ->select('id')
+                            ->select('query_name')
+                            ->select('sql_query')
+                            ->select('created_at')
+                            ->order_by_desc('created_at')
+                            ->find_array();
+            if ($queries !== false) {
+                $saved_queries = $queries;
+            }
+        } catch (Exception $e) {
+            // Log error or handle gracefully
+            error_log("Error fetching saved queries for dashboard: " . $e->getMessage());
+            // $saved_queries will remain empty, view should handle this
+        }
+
         Flight::render(
            'dashboard',
            array(
               'title' => self::$title,
-              'icon' => self::$icon
+              'icon' => self::$icon,
+              'saved_queries' => $saved_queries
            )
         );
     }

--- a/app/views/dashboard.php
+++ b/app/views/dashboard.php
@@ -1,11 +1,41 @@
 <?php require_once 'includes/header.php'; ?>
 
     <div class="page-content inset">
-        <div class="row" style="margin-top: -20px;">
-            <div class="alert alert-info">
-                <h3 style="margin: 0;"><span class="fa fa-table"></span> Please select a table from left :)</h3>
+        <div class="row">
+            <h4><i class="fa fa-list-alt"></i> Saved Queries</h4>
+            <hr>
+            <?php if (!empty($saved_queries)): ?>
+                <ul class="list-group" id="dashboardSavedQueriesList">
+                    <?php foreach ($saved_queries as $query): ?>
+                        <li class="list-group-item d-flex justify-content-between align-items-center" data-query-list-id="<?php echo htmlspecialchars($query['id']); ?>">
+                            <?php echo htmlspecialchars($query['query_name']); ?>
+                            <div style="float: right;"> <!-- Group buttons on the right -->
+                                <button type="button" class="btn btn-primary btn-xs btn-run-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" style="margin-left: 10px;">
+                                    <i class="fa fa-play"></i> Run
+                                </button>
+                                <button type="button" class="btn btn-danger btn-xs btn-delete-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 5px;">
+                                    <i class="fa fa-trash-o"></i> Delete
+                                </button>
+                            </div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php else: ?>
+                <div class="alert alert-info">
+                    <p><span class="fa fa-info-circle"></span> You have no saved queries yet. You can save a query after running it from the table view.</p>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div class="row" style="margin-top: 40px;">
+             <div class="alert alert-info">
+                <h3 style="margin: 0;"><span class="fa fa-table"></span> To build or run new queries, please select a table from the sidebar.</h3>
             </div>
         </div>
     </div>
+
+<script>
+    // Make saved queries available to JavaScript (for run/delete handlers that might use savedQueriesCache)
+    var initialSavedQueries = <?php echo json_encode($saved_queries ?? []); ?>;
+</script>
 
 <?php require_once 'includes/footer.php'; ?>

--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -43,11 +43,7 @@
 
         <ul class="sidebar-nav">
             <?php echo Flight::get('tables'); ?>
-            <li style="margin-top: 15px;">
-                <a href="#" data-toggle="modal" data-target="#modal-list-queries">
-                    <i class="fa fa-list-alt"></i> Saved Queries
-                </a>
-            </li>
+            <!-- Saved Queries link removed, queries are now shown on dashboard -->
         </ul>
     </div>
     <!-- End Sidebar -->

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -276,31 +276,6 @@ $fields = $fields ?? [];
     <div class="clearfix"></div>
 </div>
 
-<!-- List Saved Queries Modal -->
-<div class="modal fade" id="modal-list-queries">
-    <div class="modal-dialog modal-lg"> <!-- Larger modal for better list display -->
-        <div class="modal-content">
-            <div class="modal-header label-info">
-                <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <h4 class="modal-title"><i class="fa fa-list-alt"></i> Saved Queries</h4>
-            </div>
-            <div class="modal-body">
-                <div id="listQueriesMsg" class="alert" style="display:none;"></div>
-                <button type="button" class="btn btn-default btn-sm" id="btnRefreshSavedQueries" style="margin-bottom: 10px;">
-                    <i class="fa fa-refresh"></i> Refresh List
-                </button>
-                <div id="savedQueriesListContainer" style="max-height: 400px; overflow-y: auto;">
-                    <!-- Saved queries will be listed here by JavaScript -->
-                    <p>Loading...</p>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <!-- Save Query Modal -->
 <div class="modal fade" id="modal-save-query">
     <div class="modal-dialog">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -160,26 +160,20 @@ $('body').on('click', '.btn-run-saved-query', function() {
     }
 });
 
-// --- Delete Saved Query Functionality ---
+// --- Delete Saved Query Functionality (for dashboard and potentially modals if reused) ---
 // Delegated click handler for the delete button on a saved query item
 $('body').on('click', '.btn-delete-saved-query', function() {
     var queryId = $(this).data('query-id');
-    var queryName = $(this).data('query-name'); // Get the name for the confirmation message
+    var queryName = $(this).data('query-name');
 
-    // Store the queryId on the confirmation modal's delete button
-    // This is one way to pass the ID to the actual delete action
     $('#modal-delete-confirm').data('query-id-to-delete', queryId);
-
-    // Customize confirmation message (optional, if the modal can display dynamic text)
-    // For now, relying on the generic message in #modal-delete-confirm
-    // If #modal-delete-confirm had a <span id="item-to-delete-name"></span>, you could do:
-    // $('#item-to-delete-name').text(queryName || 'this item');
+    // If you want to customize the confirmation modal's text:
+    // $('#modal-delete-confirm .modal-body p:first').html('You are about to delete the query: <strong>' + escapeHtml(queryName) + '</strong>. This procedure is irreversible.');
 
     $('#modal-delete-confirm').modal('show');
 });
 
 // Click handler for the final delete confirmation button inside #modal-delete-confirm
-// Assumes #modal-delete-confirm has a button with class .btnDelete (as per modals.php)
 $('#modal-delete-confirm').on('click', '.btnDelete', function() {
     var queryIdToDelete = $('#modal-delete-confirm').data('query-id-to-delete');
 
@@ -189,8 +183,8 @@ $('#modal-delete-confirm').on('click', '.btnDelete', function() {
         return;
     }
 
-    var $thisButton = $(this); // The .btnDelete inside the confirmation modal
-    $thisButton.prop('disabled', true); // Disable while processing
+    var $thisButton = $(this);
+    $thisButton.prop('disabled', true).find('i').removeClass('fa-trash-o').addClass('fa-spinner fa-spin');
 
     $.ajax({
         url: base + '/ajax/deleteQuery',
@@ -201,17 +195,22 @@ $('#modal-delete-confirm').on('click', '.btnDelete', function() {
             if (response.status === 'success') {
                 $.jGrowl(response.message || 'Query deleted successfully!', { header: 'Success', theme: 'success' });
 
-                // Remove the item from the list in #modal-list-queries
-                $('#savedQueriesListContainer li[data-query-list-id="' + queryIdToDelete + '"]').fadeOut(function() {
+                // Remove the item from the list (works for both dashboard and previous modal list)
+                $('li[data-query-list-id="' + queryIdToDelete + '"]').fadeOut(function() {
                     $(this).remove();
-                    if ($('#savedQueriesListContainer li').length === 0) {
-                        $('#savedQueriesListContainer').html('<p class="text-muted">No saved queries found.</p>');
+                    // Check if the list is empty on the dashboard specifically
+                    if ($('#dashboardSavedQueriesList li').length === 0 && $('#dashboardSavedQueriesList').length > 0) {
+                        $('#dashboardSavedQueriesList').replaceWith('<div class="alert alert-info"><p><span class="fa fa-info-circle"></span> You have no saved queries yet. You can save a query after running it from the table view.</p></div>');
+                    }
+                    // Check if the list is empty in the (now removed) modal list container
+                    if ($('#savedQueriesListContainer li').length === 0 && $('#savedQueriesListContainer').length > 0) {
+                         $('#savedQueriesListContainer').html('<p class="text-muted">No saved queries found.</p>');
                     }
                 });
 
                 // Remove from cache
                 savedQueriesCache = savedQueriesCache.filter(function(query) {
-                    return query.id != queryIdToDelete;
+                    return query.id != queryIdToDelete; // Use loose equality as data attributes can be strings
                 });
 
             } else {
@@ -223,12 +222,18 @@ $('#modal-delete-confirm').on('click', '.btnDelete', function() {
         },
         complete: function() {
             $('#modal-delete-confirm').modal('hide');
-            $thisButton.prop('disabled', false); // Re-enable button
-            $('#modal-delete-confirm').removeData('query-id-to-delete'); // Clean up
+            $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-trash-o');
+            $('#modal-delete-confirm').removeData('query-id-to-delete');
         }
     });
 });
 
+$(document).ready(function() {
+    // Populate savedQueriesCache if initialSavedQueries is available (from dashboard.php)
+    if (typeof initialSavedQueries !== 'undefined' && Array.isArray(initialSavedQueries)) {
+        savedQueriesCache = initialSavedQueries;
+    }
+});
 
 function updateHavingFieldNameOptions() {
     var options = [];
@@ -463,73 +468,30 @@ $('body').on('click', '#btnSaveQueryConfirm', function() {
 });
 
 
-// --- List Saved Queries Functionality ---
-var savedQueriesCache = []; // Simple cache for query SQL
+// --- List Saved Queries Functionality (Obsolete, kept for reference during cleanup, will be removed) ---
+// var savedQueriesCache = []; // This is now initialized by initialSavedQueries if on dashboard
 
+/* // Obsolete: fetchAndDisplaySavedQueries function
 function fetchAndDisplaySavedQueries() {
-    var $container = $('#savedQueriesListContainer');
-    var $msgContainer = $('#listQueriesMsg');
-    $container.html('<p><i class="fa fa-spinner fa-spin"></i> Loading saved queries...</p>');
-    $msgContainer.hide();
-
-    $.ajax({
-        url: base + '/ajax/getSavedQueries',
-        type: 'GET',
-        dataType: 'json',
-        success: function(response) {
-            $container.empty(); // Clear loading message
-            if (response.status === 'success' && response.queries && response.queries.length > 0) {
-                savedQueriesCache = response.queries; // Cache the queries
-                var listHtml = '<ul class="list-group">';
-                $.each(response.queries, function(index, query) {
-                    listHtml += '<li class="list-group-item d-flex justify-content-between align-items-center" data-query-list-id="' + query.id + '">'; // Add data-query-list-id to li for easy removal
-                    listHtml += escapeHtml(query.query_name); // Display query name
-                    listHtml += '<div>'; // Group buttons
-                    listHtml += '<button type="button" class="btn btn-primary btn-xs btn-run-saved-query" data-query-id="' + query.id + '" style="margin-left: 10px;"><i class="fa fa-play"></i> Run</button>';
-                    listHtml += '<button type="button" class="btn btn-danger btn-xs btn-delete-saved-query" data-query-id="' + query.id + '" data-query-name="' + escapeHtml(query.query_name) + '" style="margin-left: 5px;"><i class="fa fa-trash-o"></i> Delete</button>';
-                    listHtml += '</div>';
-                    listHtml += '</li>';
-                });
-                listHtml += '</ul>';
-                $container.html(listHtml);
-            } else if (response.status === 'success') {
-                $container.html('<p class="text-muted">No saved queries found.</p>');
-            }
-            else {
-                $msgContainer.removeClass('alert-success').addClass('alert-danger').text(response.message || 'Could not load saved queries.').show();
-                $container.html('<p class="text-danger">Error loading queries.</p>');
-            }
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-            $container.html('<p class="text-danger">Error loading queries.</p>');
-            $msgContainer.removeClass('alert-success').addClass('alert-danger').text('AJAX Error: ' + textStatus + ' - ' + errorThrown).show();
-        }
-    });
+    // ... content removed ...
 }
+*/
 
-// Using escapeHtml to prevent XSS from query names
+/* // Obsolete: escapeHtml function (if only used by fetchAndDisplaySavedQueries)
 function escapeHtml(unsafe) {
-    if (unsafe === null || typeof unsafe === 'undefined') {
-        return '';
-    }
-    return unsafe
-         .replace(/&/g, "&amp;")
-         .replace(/</g, "&lt;")
-         .replace(/>/g, "&gt;")
-         .replace(/"/g, "&quot;")
-         .replace(/'/g, "&#039;");
- }
+    // ... content removed ...
+}
+*/
 
-// When the "List Saved Queries" modal is shown, fetch the list
+/* // Obsolete: Modal event listeners for list queries
 $('#modal-list-queries').on('show.bs.modal', function () {
-    fetchAndDisplaySavedQueries();
+    // fetchAndDisplaySavedQueries(); // Removed
 });
 
-// Refresh button click
 $('body').on('click', '#btnRefreshSavedQueries', function() {
-    fetchAndDisplaySavedQueries();
+    // fetchAndDisplaySavedQueries(); // Removed
 });
-
+*/
 
 $('#addjoinedtablefields').click(addTablesToDropdown);
 


### PR DESCRIPTION
This commit changes the user interface to display the list of saved queries directly on the main dashboard/welcome page, removing the previous modal-based approach for listing them.

Key changes:

1.  **Dashboard Controller (`app/controllers/dashboard.php`):**
    *   The `index()` method now fetches all saved queries (id, name, SQL,
      timestamp) from the database.
    *   This list of queries is passed to the `dashboard` view.

2.  **Dashboard View (`app/views/dashboard.php`):**
    *   Updated to iterate through the fetched `$saved_queries`.
    *   Displays each query's name along with "Run" and "Delete" buttons.
      These buttons use the same classes and data attributes as before to
      ensure existing JavaScript handlers function correctly.
    *   Shows a message if no saved queries are found.
    *   The `$saved_queries` array (including the SQL) is embedded as a
      JavaScript variable `initialSavedQueries`.

3.  **JavaScript (`assets/js/custom.js`):**
    *   On document ready, `savedQueriesCache` is now populated from the
      `initialSavedQueries` variable if present (on the dashboard page).
      This ensures the "Run" button functionality remains intact.
    *   The success callback for the delete query AJAX request has been
      updated to correctly remove items from the dashboard list and
      handle the empty state display on the dashboard.
    *   Removed the `fetchAndDisplaySavedQueries()` function and associated
      event listeners (`show.bs.modal` for `#modal-list-queries`, click
      handler for `#btnRefreshSavedQueries`) as they are no longer needed.

4.  **UI Cleanup:**
    *   Removed the HTML for `#modal-list-queries` from
      `app/views/includes/modals.php`.
    *   Removed the "Saved Queries" link from the sidebar in
      `app/views/includes/header.php` that previously triggered the modal.

This change aims to improve user experience by making saved queries more immediately accessible.