### PR TITLE
Streamline 'Run Saved Query' to bypass Custom Query modal

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -112,7 +112,8 @@ $('body').on('change', '.agg_alias, .groupfields', function() {
 });
 
 // Run Saved Query
-$('body').on('click', '.btn-run-saved-query', function() {
+$('body').on('click', '.btn-run-saved-query', function(e) {
+    e.preventDefault(); // Prevent default anchor action if it were an <a> tag
     var queryId = $(this).data('query-id');
     var queryToRun = null;
 
@@ -179,10 +180,27 @@ $('body').on('click', '.btn-run-saved-query', function() {
         // Open the custom query modal and then click its run button
         $('#modal-custom-query').modal('show');
 
-        // Ensure modal is shown before clicking run, using Bootstrap's event
-        $('#modal-custom-query').one('shown.bs.modal', function () {
-            $('#btnCustomQuery').click();
-        });
+        // Dynamically create and submit a hidden form
+        var $form = $('<form>', {
+            'action': formAction,
+            'method': 'POST',
+            'style': 'display:none;'
+        }).append($('<input>', {
+            'type': 'hidden',
+            'name': 'cquery',
+            'value': queryToRun.sql_query
+        }));
+
+        // If the original custom query form has other specific hidden inputs that Table::runquery might expect,
+        // they would need to be cloned here. For example, if 'vquery' or 'printArray' were relevant for non-visual runs.
+        // var $originalCustomQueryForm = $('#modal-custom-query form');
+        // $form.append($originalCustomQueryForm.find('input[name="vquery"]').clone());
+        // $form.append($originalCustomQueryForm.find('input[name="printArray"]').clone()); // This one is a checkbox, cloning needs care.
+        // For now, assuming only 'cquery' is essential for this direct run.
+
+        $('body').append($form);
+        $form.submit();
+        $form.remove();
 
     } else {
         $.jGrowl('Could not find the SQL for the selected query.', { sticky: false, header: 'Error', theme: 'error' });


### PR DESCRIPTION
This commit refactors the JavaScript handler for '.btn-run-saved-query' to execute saved queries directly, without first showing the Custom Query modal.

Key changes:
- When a 'Run' button for a saved query is clicked:
  - The SQL is retrieved from the client-side cache.
  - The target URL for the query execution is determined:
    - If on the dashboard, it defaults to the context of the first available table in the sidebar.
    - If on a specific table page, it uses the current table's context.
  - A hidden form is dynamically created with the saved SQL in the 'cquery' field and the determined action URL.
  - This form is submitted directly, leading the user to the results page.
- This removes the intermediate step of displaying the SQL in the Custom Query modal before execution.
- Fixes the 404 error previously encountered when trying to run saved queries from the dashboard page due to a missing table context in the form submission URL.