### PR TITLE
Fix: Edit button now opens the correct modal for saved queries

### DIFF
--- a/app/controllers/dashboard.php
+++ b/app/controllers/dashboard.php
@@ -16,6 +16,8 @@ class Dashboard
                             ->select('id')
                             ->select('query_name')
                             ->select('sql_query')
+                            ->select('is_visual_query')
+                            ->select('visual_params')
                             ->select('created_at')
                             ->order_by_desc('created_at')
                             ->find_array();


### PR DESCRIPTION
This commit addresses an issue where the 'Edit' button for saved queries always opened the Custom SQL Editor, regardless of whether the query was originally created with the Visual Query Builder.

Changes:

1.  **`app/controllers/dashboard.php` (`Dashboard::index()`):**
    *   Modified the database query to fetch the `is_visual_query` and
      `visual_params` columns for all saved queries. This data is now
      passed to the `dashboard.php` view and made available to client-side
      JavaScript via the `initialSavedQueries` variable.

2.  **`assets/js/custom.js` (`.btn-edit-saved-query` handler):**
    *   The click handler for the 'Edit' button now retrieves the
      `is_visual_query` flag and `visual_params` string from the
      `savedQueriesCache` (which is populated from `initialSavedQueries`).
    *   Based on these values:
        *   If `is_visual_query` is true and `visual_params` are present,
          it populates the ID and Name fields within `#modal-visual-query`
          and shows this modal. (Full population of visual builder elements
          from `visual_params` is a pending task for a future feature).
        *   Otherwise (custom SQL query or missing visual params), it
          falls back to the existing behavior of populating and showing
          the `#modal-custom-query` with the SQL.

This ensures that users are directed to the appropriate editor based on how the query was originally created and saved.