### PR TITLE
Fix: Correct SQL join condition generation

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -217,8 +217,31 @@ class Table
 
                     // build ON table join clause
                     if ($_POST['jointable'][$key]) {
-                        $query .= $_POST['jointable'][$key];
-                        $query .= ' ON ' . $primaryTable . '.`' . $_POST['joinfieldp'][$key] . '` = ' . $_POST['jointable'][$key] . '.`' . $_POST['joinfield'][$key] . '`';
+                        $query .= '`' . str_replace('`', '``', $_POST['jointable'][$key]) . '`'; // Quote the joined table name
+
+                        // Primary table's join field
+                        $primary_join_field = $_POST['joinfieldp'][$key];
+                        if (strpos($primary_join_field, '.') !== false) {
+                            // Field is already qualified (e.g., table.column)
+                            list($pt_table, $pt_col) = explode('.', $primary_join_field, 2);
+                            $primary_join_field_sql = '`' . str_replace('`', '``', $pt_table) . '`.`' . str_replace('`', '``', $pt_col) . '`';
+                        } else {
+                            // Field is not qualified, prepend primary table name
+                            $primary_join_field_sql = '`' . str_replace('`', '``', $primaryTable) . '`.`' . str_replace('`', '``', $primary_join_field) . '`';
+                        }
+
+                        // Joined table's join field
+                        $secondary_join_field = $_POST['joinfield'][$key];
+                        if (strpos($secondary_join_field, '.') !== false) {
+                            // Field is already qualified (e.g., table.column)
+                            list($st_table, $st_col) = explode('.', $secondary_join_field, 2);
+                            $secondary_join_field_sql = '`' . str_replace('`', '``', $st_table) . '`.`' . str_replace('`', '``', $st_col) . '`';
+                        } else {
+                            // Field is not qualified, prepend joined table name
+                            $secondary_join_field_sql = '`' . str_replace('`', '``', $_POST['jointable'][$key]) . '`.`' . str_replace('`', '``', $secondary_join_field) . '`';
+                        }
+
+                        $query .= ' ON ' . $primary_join_field_sql . ' = ' . $secondary_join_field_sql;
                     }
                 }
             }


### PR DESCRIPTION
The visual query builder was producing an error due to incorrect concatenation of table and column names in JOIN clauses. Specifically, the primary table's name was being prepended to a field name that already included the table qualifier (e.g., 'querytest.querytest.id' instead of 'querytest.id').

This commit modifies `app/controllers/table.php` to:
- Check if join field names (`joinfieldp` and `joinfield` from POST data) already contain a dot ('.'), indicating they are fully qualified.
- If qualified, use the field name as is (after proper quoting).
- If not qualified, prepend the appropriate table name (primary or joined table) before quoting.
- Ensure consistent backtick quoting for all table and column identifiers in the join condition to prevent SQL errors and improve security.

This change ensures the generated SQL for JOIN clauses uses the correct `table`.`column` format, resolving the 'Unknown column' error.