### PR TITLE
Refactor: Separate query renaming into dedicated modal

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -72,33 +72,82 @@ class Ajax
         header('Content-Type: application/json');
         $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
-        if (empty($_POST['query_name']) || empty($_POST['sql_query'])) {
-            $response['message'] = 'Query name and SQL query cannot be empty.';
-            echo json_encode($response);
-            return;
+        $query_id = $_POST['query_id'] ?? null;
+        // Use null coalescing and provide default empty string for trim if not set
+        $query_name = trim($_POST['query_name'] ?? '');
+        $sql_query = $_POST['sql_query'] ?? null;
+        $is_visual_query_provided = isset($_POST['is_visual_query']);
+        $visual_params_provided = isset($_POST['visual_params']);
+
+        if ($query_id && is_numeric($query_id)) { // This is an UPDATE operation
+            $has_name_to_update = isset($_POST['query_name']); // Check if 'query_name' key was sent
+            $has_sql_to_update = isset($_POST['sql_query']);   // Check if 'sql_query' key was sent
+            $has_visual_to_update = $is_visual_query_provided; // Check if 'is_visual_query' was sent
+
+            // If query_name is explicitly sent, it must not be empty
+            if ($has_name_to_update && empty($query_name)) {
+                $response['message'] = 'Query name cannot be empty when provided for an update.';
+                echo json_encode($response);
+                return;
+            }
+
+            // If sql_query is explicitly sent, it must not be empty
+            if ($has_sql_to_update && empty($sql_query)) {
+                $response['message'] = 'SQL query cannot be empty when provided for an update.';
+                echo json_encode($response);
+                return;
+            }
+
+            // At least one field must be intended for update if query_id is present
+            if (!$has_name_to_update && !$has_sql_to_update && !$has_visual_to_update) {
+                 $response['message'] = 'No data provided to update for existing query.';
+                 echo json_encode($response);
+                 return;
+            }
+
+        } else { // This is a CREATE operation
+            if (empty($query_name) || empty($sql_query)) {
+                $response['message'] = 'For a new query, name and SQL query cannot be empty.';
+                echo json_encode($response);
+                return;
+            }
         }
 
-        $query_name = trim($_POST['query_name']);
-        $sql_query = $_POST['sql_query'];
-        $query_id = $_POST['query_id'] ?? null;
-        $is_visual_query = isset($_POST['is_visual_query']) ? filter_var($_POST['is_visual_query'], FILTER_VALIDATE_BOOLEAN) : false;
-        $visual_params = ($is_visual_query && isset($_POST['visual_params'])) ? $_POST['visual_params'] : null;
+        $is_visual_query = $is_visual_query_provided ? filter_var($_POST['is_visual_query'], FILTER_VALIDATE_BOOLEAN) : false;
+        $visual_params = ($is_visual_query && $visual_params_provided) ? $_POST['visual_params'] : null;
 
         try {
             if ($query_id && is_numeric($query_id)) {
                 // Update existing query
                 $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
                 if ($saved_query) {
-                    $saved_query->query_name = $query_name;
-                    $saved_query->sql_query = $sql_query;
-                    $saved_query->is_visual_query = $is_visual_query;
-                    $saved_query->visual_params = $is_visual_query ? $visual_params : null;
-                    // Note: created_at is not updated, consider adding an updated_at column if needed
-                    if ($saved_query->save()) {
-                        $response['status'] = 'success';
-                        $response['message'] = 'Query "' . htmlspecialchars($query_name) . '" updated successfully!';
+                    $updated_fields_count = 0;
+                    if (isset($_POST['query_name'])) {
+                        $saved_query->query_name = $query_name; // Already trimmed
+                        $updated_fields_count++;
+                    }
+                    if (isset($_POST['sql_query'])) {
+                        $saved_query->sql_query = $sql_query;
+                        $updated_fields_count++;
+                    }
+                    if ($is_visual_query_provided) { // Update visual only if is_visual_query was part of the request
+                        $saved_query->is_visual_query = $is_visual_query;
+                        $saved_query->visual_params = $is_visual_query ? $visual_params : null;
+                        $updated_fields_count++;
+                    }
+
+                    if ($updated_fields_count > 0) {
+                        if ($saved_query->save()) {
+                            $response['status'] = 'success';
+                            $response['message'] = 'Query "' . htmlspecialchars($saved_query->query_name) . '" updated successfully!';
+                        } else {
+                            $response['message'] = 'Failed to update query in the database.';
+                        }
                     } else {
-                        $response['message'] = 'Failed to update query in the database.';
+                         // This case should ideally be caught by earlier validation,
+                         // but as a safeguard if somehow fields were present but not set on $saved_query.
+                        $response['message'] = 'No changes detected to save for the query.';
+                        $response['status'] = 'info'; // Or 'success' if no change is not an error
                     }
                 } else {
                     $response['message'] = 'Query not found for update.';
@@ -106,8 +155,8 @@ class Ajax
             } else {
                 // Create new query
                 $saved_query = ORM::for_table('saved_queries')->create();
-                $saved_query->query_name = $query_name;
-                $saved_query->sql_query = $sql_query;
+                $saved_query->query_name = $query_name; // Already trimmed
+                $saved_query->sql_query = $sql_query; // Must be present due to earlier check
                 $saved_query->is_visual_query = $is_visual_query;
                 $saved_query->visual_params = $is_visual_query ? $visual_params : null;
                 // created_at is handled by database default

--- a/app/views/dashboard.php
+++ b/app/views/dashboard.php
@@ -10,8 +10,11 @@
                         <li class="list-group-item d-flex justify-content-between align-items-center" data-query-list-id="<?php echo htmlspecialchars($query['id']); ?>">
                             <?php echo htmlspecialchars($query['query_name']); ?>
                             <div style="float: right;"> <!-- Group buttons on the right -->
-                                <button type="button" class="btn btn-info btn-sm btn-edit-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 10px;">
-                                    <i class="fa fa-pencil"></i> Edit
+                                <button type="button" class="btn btn-warning btn-sm btn-rename-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 10px;">
+                                    <i class="fa fa-i-cursor"></i> Rename
+                                </button>
+                                <button type="button" class="btn btn-info btn-sm btn-edit-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 5px;">
+                                    <i class="fa fa-pencil"></i> Edit SQL/Visual
                                 </button>
                                 <button type="button" class="btn btn-primary btn-sm btn-run-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" style="margin-left: 5px;">
                                     <i class="fa fa-play"></i> Run

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -68,10 +68,6 @@ $fields = $fields ?? [];
                 <div class="modal-body">
                     <input type="hidden" id="custom_query_id_edit" name="custom_query_id_edit">
                     <div class="form-group">
-                        <label for="custom_query_name_edit">Query Name:</label>
-                        <input type="text" class="form-control" id="custom_query_name_edit" name="custom_query_name_edit" placeholder="Enter a name for this query">
-                    </div>
-                    <div class="form-group">
                         <label>SQL Query:</label>
                         <div id="ace" style="height: 250px; width: 100%;"></div>
                     </div>
@@ -114,10 +110,6 @@ $fields = $fields ?? [];
 
                 <div class="modal-body">
                     <input type="hidden" id="visual_query_id_edit" name="visual_query_id_edit">
-                    <div class="form-group">
-                        <label for="visual_query_name_edit">Query Name:</label>
-                        <input type="text" class="form-control" id="visual_query_name_edit" name="visual_query_name_edit" placeholder="Enter a name for this query">
-                    </div>
                      <hr>
 
                     <div class="form-group">
@@ -299,6 +291,29 @@ $fields = $fields ?? [];
     <div class="clearfix"></div>
 </div>
 
+<!-- Rename Query Modal -->
+<div class="modal fade" id="modal-rename-query">
+    <div class="modal-dialog modal-sm"> <!-- Using modal-sm for a smaller modal -->
+        <div class="modal-content">
+            <div class="modal-header label-info"> <!-- Changed color for distinction -->
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title"><i class="fa fa-pencil"></i> Rename Query</h4>
+            </div>
+            <div class="modal-body">
+                <div id="renameQueryMsg" class="alert" style="display:none;"></div>
+                <input type="hidden" id="rename_query_id" name="rename_query_id">
+                <div class="form-group">
+                    <label for="rename_query_name">New Query Name:</label>
+                    <input type="text" class="form-control" id="rename_query_name" name="rename_query_name" required>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Cancel</button>
+                <button type="button" class="btn btn-primary" id="btnSaveRenameQuery"><i class="fa fa-save"></i> Save Rename</button>
+            </div>
+        </div>
+    </div>
+</div>
 <!-- Save Query Modal -->
 <div class="modal fade" id="modal-save-query">
     <div class="modal-dialog">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -214,10 +214,10 @@ $('body').on('click', '.btn-edit-saved-query', function() {
     if (isVisual && visualParams && visualParams !== '') {
         // Populate and show Visual Query Modal
         $('#visual_query_id_edit').val(queryId);
-        $('#visual_query_name_edit').val(queryName);
+        // Name is no longer edited in this modal
         // TODO: Implement populateVisualQueryModal(JSON.parse(visualParams));
         // For now, just opening it with name and ID. User has to rebuild.
-        console.log("Attempting to open visual editor for:", queryName, "Params:", visualParams);
+        console.log("Attempting to open visual editor for query ID:", queryId, "Params:", visualParams);
         $.jGrowl('Populating visual editor from saved params is not yet fully implemented. Opening with name/ID.', { header: 'Info', theme: 'info', life: 5000});
 
         // Set form action for the visual query modal's run button (if it submits directly)
@@ -251,7 +251,7 @@ $('body').on('click', '.btn-edit-saved-query', function() {
             console.warn('ACE editor not found. SQL set in hidden input for custom query.');
         }
         $('#custom_query_id_edit').val(queryId);
-        $('#custom_query_name_edit').val(queryName);
+        // Name is no longer edited in this modal
         $('#updateCustomQueryMsg').hide().removeClass('alert-success alert-danger').text('');
 
         var onDashboardCtxSql = (!lastSegment || lastSegment === 'home' || lastSegment === 'dashboard');
@@ -277,20 +277,23 @@ $('body').on('click', '.btn-edit-saved-query', function() {
 });
 
 // --- Update Saved Query (from Custom Query Modal) ---
+// This button is now primarily for updating the SQL of an existing query.
+// Name editing is handled by the new Rename modal.
 $('body').on('click', '#btnUpdateSavedQuery', function() {
     var queryId = $('#custom_query_id_edit').val();
-    var queryName = $('#custom_query_name_edit').val();
+    // var queryName = $('#custom_query_name_edit').val(); // Field removed from modal
     var sqlQuery = (typeof editor !== 'undefined' && editor !== null) ? editor.getValue() : $('#cquery').val(); // Get SQL from ACE or fallback
     var $msgContainer = $('#updateCustomQueryMsg');
 
     if (!queryId) {
-        $msgContainer.removeClass('alert-success').addClass('alert-danger').text('Error: Query ID is missing. Cannot update.').show();
+        $msgContainer.removeClass('alert-success').addClass('alert-danger').text('Error: Query ID is missing. Cannot update SQL.').show();
         return;
     }
-    if ($.trim(queryName) === '') {
-        $msgContainer.removeClass('alert-success').addClass('alert-danger').text('Query name cannot be empty.').show();
-        return;
-    }
+    // Query name validation removed as it's not edited here.
+    // if ($.trim(queryName) === '') {
+    //     $msgContainer.removeClass('alert-success').addClass('alert-danger').text('Query name cannot be empty.').show();
+    //     return;
+    // }
     if ($.trim(sqlQuery) === '') {
         $msgContainer.removeClass('alert-success').addClass('alert-danger').text('SQL query is empty. Cannot update.').show();
         return;
@@ -299,10 +302,12 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
     var $thisButton = $(this);
     $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
 
+    // query_name is removed from this request. The backend should only update the SQL.
     var ajaxData = {
         query_id: queryId,
-        query_name: queryName,
         sql_query: sqlQuery
+        // If visual_params were ever relevant here, they'd be included.
+        // For now, this modal seems to be for raw SQL queries.
     };
 
     $.ajax({
@@ -314,20 +319,20 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
             if (response.status === 'success') {
                 $msgContainer.removeClass('alert-danger').addClass('alert-success').text(response.message).show();
 
-                // Update cache
+                // Update cache for sql_query
                 if (typeof savedQueriesCache !== 'undefined') {
                     var itemInCache = savedQueriesCache.find(function(q) { return q.id == queryId; });
                     if (itemInCache) {
-                        itemInCache.query_name = queryName;
+                        // itemInCache.query_name = queryName; // Name is not updated here
                         itemInCache.sql_query = sqlQuery;
                     }
                 }
-                // Update dashboard list item
-                var $listItem = $('li[data-query-list-id="' + queryId + '"]');
-                if ($listItem.length) {
-                    $listItem.contents().filter(function() { return this.nodeType === 3; }).first().replaceWith(escapeHtml(queryName));
-                    $listItem.find('.btn-edit-saved-query, .btn-delete-saved-query').data('query-name', queryName);
-                }
+                // Update dashboard list item - only SQL changes, name display is not affected by this action.
+                // var $listItem = $('li[data-query-list-id="' + queryId + '"]');
+                // if ($listItem.length) {
+                //    $listItem.contents().filter(function() { return this.nodeType === 3; }).first().replaceWith(escapeHtml(queryName));
+                //    $listItem.find('.btn-edit-saved-query, .btn-delete-saved-query').data('query-name', queryName);
+                // }
 
                 setTimeout(function() {
                     $msgContainer.fadeOut(function() { $(this).hide(); });
@@ -680,6 +685,97 @@ $('body').on('click', '#btnSaveQueryConfirm', function() {
 // Clear visual_params data if the save modal is closed manually
 $('#modal-save-query').on('hidden.bs.modal', function () {
     $(this).removeData('visual-params');
+});
+
+// Basic HTML escaping function
+function escapeHtml(unsafe) {
+    if (typeof unsafe !== 'string') {
+        return ''; // Or handle other types as needed
+    }
+    return unsafe
+         .replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
+}
+
+// --- Rename Saved Query ---
+// Show Rename Query Modal
+$('body').on('click', '.btn-rename-query', function() {
+    var queryId = $(this).data('query-id');
+    var currentQueryName = $(this).data('query-name');
+
+    $('#rename_query_id').val(queryId);
+    $('#rename_query_name').val(currentQueryName); // Populate with current name
+    $('#renameQueryMsg').hide().removeClass('alert-success alert-danger').text('');
+    $('#modal-rename-query').modal('show');
+});
+
+// Handle saving the renamed query
+$('body').on('click', '#btnSaveRenameQuery', function() {
+    var queryId = $('#rename_query_id').val();
+    var newQueryName = $('#rename_query_name').val();
+    var $msgContainer = $('#renameQueryMsg');
+    var $thisButton = $(this);
+
+    if ($.trim(newQueryName) === '') {
+        $msgContainer.removeClass('alert-success').addClass('alert-danger').text('Query name cannot be empty.').show();
+        return;
+    }
+
+    $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
+
+    var ajaxData = {
+        query_id: queryId,
+        query_name: newQueryName
+        // No sql_query or visual_params are sent, as we are only renaming.
+    };
+
+    $.ajax({
+        url: base + '/ajax/saveQuery', // Use the existing endpoint
+        type: 'POST',
+        data: ajaxData,
+        dataType: 'json',
+        success: function(response) {
+            if (response.status === 'success') {
+                $msgContainer.removeClass('alert-danger').addClass('alert-success').text(response.message || 'Query renamed successfully!').show();
+
+                // Update cache
+                if (typeof savedQueriesCache !== 'undefined') {
+                    var itemInCache = savedQueriesCache.find(function(q) { return q.id == queryId; });
+                    if (itemInCache) {
+                        itemInCache.query_name = newQueryName;
+                    }
+                }
+
+                // Update dashboard list item text and data attribute
+                var $listItem = $('li[data-query-list-id="' + queryId + '"]');
+                if ($listItem.length) {
+                    // Update the text node directly
+                    $listItem.contents().filter(function() {
+                        return this.nodeType === 3; // Node.TEXT_NODE
+                    }).first().replaceWith(escapeHtml(newQueryName));
+
+                    // Update data-query-name on relevant buttons within this list item
+                    $listItem.find('.btn-edit-saved-query, .btn-delete-saved-query, .btn-rename-query').data('query-name', newQueryName);
+                }
+
+                setTimeout(function() {
+                    $msgContainer.fadeOut(function() { $(this).hide().text(''); });
+                    $('#modal-rename-query').modal('hide');
+                }, 1500);
+            } else {
+                $msgContainer.removeClass('alert-success').addClass('alert-danger').text(response.message || 'An unknown error occurred while renaming.').show();
+            }
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $msgContainer.removeClass('alert-success').addClass('alert-danger').text('AJAX Error: ' + textStatus + ' - ' + errorThrown).show();
+        },
+        complete: function() {
+            $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-save');
+        }
+    });
 });
 
 


### PR DESCRIPTION
This commit refactors the query name editing functionality:

1.  Removed query name editing fields from the Visual Query modal (`#modal-visual-query`) and the Custom Query modal (`#modal-custom-query`). The JavaScript handlers for these modals have been updated accordingly; they no longer populate or submit query names.

2.  Added a new "Rename" button to each query in the saved queries list (in `app/views/dashboard.php`). The existing "Edit" button has been relabelled to "Edit SQL/Visual" for clarity.

3.  Created a new, dedicated modal (`#modal-rename-query` in `app/views/includes/modals.php`) specifically for renaming queries.

4.  Implemented JavaScript logic in `assets/js/custom.js` for:
    *   Populating the new rename modal with the current query ID and name.
    *   Handling the submission from the rename modal via an AJAX call to
        `/ajax/saveQuery`.
    *   Updating the `savedQueriesCache` and the query name displayed in the
        dashboard list dynamically upon successful rename.
    *   Added an `escapeHtml` utility function to JS.

5.  Modified the `saveQuery` method in `app/controllers/ajax.php` to:
    *   Handle partial updates more robustly.
    *   Allow updates to only the query name (for renaming).
    *   Allow updates to only the SQL query (from custom query modal).
    *   Allow updates to visual parameters and SQL (from visual query modal).
    *   Ensure appropriate validation for create vs. different types of
        update operations.

This change provides a more focused and clear user experience for managing query names.