### PR TITLE
Feature: Populate VQB 'fields' from saved visual_params

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -215,10 +215,35 @@ $('body').on('click', '.btn-edit-saved-query', function() {
         // Populate and show Visual Query Modal
         $('#visual_query_id_edit').val(queryId);
         // Name is no longer edited in this modal
-        // TODO: Implement populateVisualQueryModal(JSON.parse(visualParams));
-        // For now, just opening it with name and ID. User has to rebuild.
+
         console.log("Attempting to open visual editor for query ID:", queryId, "Params:", visualParams);
-        $.jGrowl('Populating visual editor from saved params is not yet fully implemented. Opening with name/ID.', { header: 'Info', theme: 'info', life: 5000});
+
+        // Attempt to populate fields from visualParams
+        try {
+            var parsedParams = JSON.parse(visualParams);
+            if (parsedParams && parsedParams.fields && Array.isArray(parsedParams.fields)) {
+                // Ensure the VQB's fields dropdown is populated for the current table context.
+                // This relies on the VQB modal already being set up for a specific table,
+                // or addTablesToDropdown() having been called appropriately.
+                var $fieldsSelect = $('#modal-visual-query').find('select.fields');
+                if ($fieldsSelect.length) {
+                    // It's crucial that $fieldsSelect options are already populated.
+                    // We assume they are, matching the context of the query being edited.
+                    $fieldsSelect.val(parsedParams.fields);
+                    $fieldsSelect.trigger('change'); // Update Select2 display
+                    $.jGrowl('Fields pre-selected from saved visual parameters.', { header: 'Info', theme: 'info', life: 3000 });
+                } else {
+                    console.warn('Could not find fields selector in VQB to pre-populate.');
+                }
+            }
+        } catch (e) {
+            console.error("Error parsing visualParams: ", e);
+            $.jGrowl('Could not parse visual parameters to pre-select fields.', { header: 'Warning', theme: 'warning', life: 3000 });
+        }
+
+        // TODO: Implement full populateVisualQueryModal(parsedParams) for other VQB elements (joins, where, etc.) in future phases.
+        // For now, the jGrowl message about partial implementation remains relevant for overall VQB state.
+        $.jGrowl('Populating visual editor from saved params is partially implemented (fields only). Other elements may need manual setup.', { header: 'Info', theme: 'info', life: 5000});
 
         // Set form action for the visual query modal's run button (if it submits directly)
         // The visual query modal's form also needs its action set correctly.


### PR DESCRIPTION
This commit implements the first phase of allowing saved queries to be edited in the Visual Query Builder (VQB) by pre-populating the 'Select Non-Aggregated Fields' dropdown.

Modifications in `assets/js/custom.js` within the
`.btn-edit-saved-query` handler:
- When a query marked as `is_visual_query=true` is opened for editing and `visual_params` are present:
  - The `visual_params` JSON string is parsed.
  - If `parsedParams.fields` exists and is an array, these field names are used to set the selected values in the VQB's primary fields multiselect dropdown (`select.fields`).
  - A Select2 change is triggered to update the UI.
  - Error handling for JSON parsing and user feedback messages (jGrowl) have been added.
- This relies on `visual_params.fields` already existing for the query. It does not attempt to parse raw SQL to generate these fields if they are not present.

No changes were needed for saving queries, as the existing logic for handling `visual_params` (i.e., saving them if provided from VQB, not altering them if saving from custom SQL editor) aligns with this feature's first phase.

Conceptual testing indicates this should correctly pre-select fields in the VQB when appropriate `visual_params` are available.