### PR TITLE
Enhance: Store fully qualified field names in visual_params

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -14,14 +14,26 @@ class Table
         try {
             // Get table structure
             $stmt = Flight::get('db')->query("DESCRIBE `$table`");
-            $fields = $stmt->fetchAll(PDO::FETCH_ASSOC);
-            $fieldOptions = getOptions(array_column($fields, 'Field'));
+            $table_fields_data = $stmt->fetchAll(PDO::FETCH_ASSOC); // Renamed to avoid conflict with $fields later
+            // Pass the table name to getOptions to generate qualified field names
+            $fieldOptions = getOptions(array_column($table_fields_data, 'Field'), false, $table);
         } catch (PDOException $e) {
-            $fields = [];
+            $table_fields_data = []; // Renamed
+            $fieldOptions = ''; // Initialize $fieldOptions in case of error
             error_log("Table structure error: ".$e->getMessage());
         }
 
-        $_SESSION['tableData'] = array();
+        // This $fields array is used for $_SESSION['tableData'], keep it as simple field names
+        $fields_for_session = array();
+        // The $columns variable seems to be fetching the same DESCRIBE info again.
+        // We can reuse $table_fields_data if it's already fetched and valid.
+        // If $table_fields_data is empty due to an earlier error, this will also be empty.
+        foreach ($table_fields_data as $values) {
+            if (isset($values['Field'])) {
+                $fields_for_session[] = $values['Field'];
+            }
+        }
+        $_SESSION['tableData'] = array(); // Initialize
 
         // Checks whether or not user is logged in
         self::checkLogin();
@@ -40,21 +52,14 @@ class Table
 
         $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
 
-        // table columns
-        $stmt = Flight::get('db')->query("DESCRIBE " . Flight::get('lastSegment'));
-        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
-        //pretty_print($columns);
+        // $fields_for_session is already populated from $table_fields_data earlier
+        // No need for the second DESCRIBE query for $columns or re-populating $fields.
 
-        $fields = array();
-        foreach ($columns as $values) {
-            if (isset($values['Field'])) {
-                $fields[] = $values['Field'];
-            }
-        }
-        //pretty_print($fields);
+        //pretty_print($fields_for_session);
 
         // store table fields/columns + data rows in session for exporting later
-        $_SESSION['tableData'] = array_merge($fields, $records);
+        // Ensure $fields_for_session is used here instead of an undefined $fields
+        $_SESSION['tableData'] = array_merge($fields_for_session, $records);
 
 
         $fieldTypes = array();
@@ -406,7 +411,7 @@ foreach ($data as $row) {
               'title' => Flight::get('lastSegment'),
               'icon' => self::$icon,
               'table_data' => $records,
-              'fields' => getOptions($fields),
+              'fields' => getOptions($fields, false, Flight::get('lastSegment')), // Pass table name
               'query' => SqlFormatter::format($query),
               'printArray' => $printArray,
               'timetaken' => $exec_time_row[0][1],


### PR DESCRIPTION
This commit ensures that the `fields` array within the `visual_params` JSON (stored for saved visual queries) consistently uses fully qualified `tablename.fieldname` format for all selected fields.

Changes made:
1.  Modified `app/controllers/table.php` (`Table::index()` method):
    *   The call to the `getOptions()` helper function (from `func.php`)
        when generating the initial list of fields for the Visual Query
        Builder (VQB) now includes the primary table name.
    *   The `getOptions()` function already had a parameter (`$tableNameAppend`)
        to support this; it's now being utilized correctly for the initial
        field population.
    *   This ensures that `<option>` values in the VQB's main "Fields"
        select dropdown are in `tablename.fieldname` format from the outset.

2.  Modified `app/controllers/table.php` (`Table::runQueryWithView()` method):
    *   Updated a similar call to `getOptions()` to also pass the table name
        for consistency in how field option lists are generated for the view.

3.  Verified `app/controllers/ajax.php` (`Ajax::getselectfields()`):
    *   This method, used when adding joined tables or refreshing fields in VQB,
        already correctly generates `tablename.fieldname` option values.

By ensuring that the VQB's field selection dropdowns always use qualified `tablename.fieldname` for their option values, the `$_POST['fields']` array submitted from the VQB will contain these qualified names. The existing logic for saving `visual_params` then naturally stores these qualified names in the JSON, improving consistency and robustness for features like pre-selecting fields when editing a saved visual query.