### PR TITLE
Feature: Display executed saved query name in header and title

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -116,9 +116,11 @@ class Table
         }
         //pretty_print($fields);
 
+        $running_saved_query_name = $_POST['running_saved_query_name'] ?? null;
+
         // for custom query
         if ($query) {
-            self::runQueryWithView($query, $fields, $printArray);
+            self::runQueryWithView($query, $fields, $printArray, null, $running_saved_query_name);
 
         } // for visual query
         else {
@@ -359,12 +361,13 @@ class Table
             }
 
             // run query and render view
-            self::runQueryWithView($query, $fields, $printArray, $visual_params_for_view);
+            // Pass $running_saved_query_name which would be null here as this is VQB path
+            self::runQueryWithView($query, $fields, $printArray, $visual_params_for_view, $running_saved_query_name);
         }
 
     }
 
-    private static function runQueryWithView($query, $fields, $printArray, $visual_query_params = null)
+    private static function runQueryWithView($query, $fields, $printArray, $visual_query_params = null, $running_saved_query_name = null)
     {
         $_SESSION['tableData'] = array();
 
@@ -415,7 +418,8 @@ foreach ($data as $row) {
               'query' => SqlFormatter::format($query),
               'printArray' => $printArray,
               'timetaken' => $exec_time_row[0][1],
-              'visual_params_json' => $visual_query_params ? json_encode($visual_query_params) : ''
+              'visual_params_json' => $visual_query_params ? json_encode($visual_query_params) : '',
+              'executed_query_name' => $running_saved_query_name // Pass the saved query name to the view
            )
         );
     }

--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -7,7 +7,19 @@
     <link rel="shortcut icon" href="<?php echo Flight::get('base'); ?>/favicon.ico" type="image/x-icon">
     <link rel="icon" href="<?php echo Flight::get('base'); ?>/favicon.ico" type="image/x-icon">
 
-    <title><?php echo Flight::get('appname'); ?></title>
+    <title>
+        <?php
+        $page_title = Flight::get('appname'); // Default
+        if (!empty($title)) { // $title is usually the table name from Flight::get('lastSegment')
+            $page_title = "Table: " . htmlspecialchars($title) . " | " . Flight::get('appname');
+        }
+        // $executed_query_name is passed from Table::runQueryWithView
+        if (!empty($executed_query_name)) {
+            $page_title = "Query: " . htmlspecialchars($executed_query_name) . " - " . $page_title;
+        }
+        echo $page_title;
+        ?>
+    </title>
     <link href="<?php echo Flight::get('base'); ?>/assets/css/bootstrap.min.css" rel="stylesheet">
     <link href="<?php echo Flight::get('base'); ?>/assets/css/font-awesome.css" rel="stylesheet">
     <link href="<?php echo Flight::get(
@@ -52,7 +64,13 @@
     <div id="page-content-wrapper">
 
         <div class="content-header">
-            <div class="pull-left"><h1><i class="glyphicon <?php echo $icon; ?>"></i> <?php echo $title; ?></h1></div>
+            <div class="pull-left">
+                <?php if (!empty($executed_query_name)): ?>
+                    <h1><i class="fa fa-play-circle-o"></i> Query: <?php echo htmlspecialchars($executed_query_name); ?> <small>(on table: <?php echo htmlspecialchars($title); ?>)</small></h1>
+                <?php else: ?>
+                    <h1><i class="glyphicon <?php echo $icon; ?>"></i> <?php echo $title; ?></h1>
+                <?php endif; ?>
+            </div>
 
             <div class="pull-right" id="addbuttoncontainer">
                 <?php if (false !== strpos($_SERVER['REQUEST_URI'], '/table')) { ?>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -162,6 +162,10 @@ $('body').on('click', '.btn-run-saved-query', function(e) {
             'type': 'hidden',
             'name': 'cquery',
             'value': queryToRun.sql_query
+        })).append($('<input>', { // Add query name as a hidden field
+            'type': 'hidden',
+            'name': 'running_saved_query_name',
+            'value': queryToRun.query_name
         }));
 
         $('body').append($dynamicForm);


### PR DESCRIPTION
This commit enhances the UI to display the name of a saved query in the browser title and main page heading when that query is executed.

Modifications:

1.  **`assets/js/custom.js` (`.btn-run-saved-query` handler):**
    *   When a saved query is run from a list (e.g., dashboard), the
        dynamically created form now includes a hidden input field
        `running_saved_query_name`, populated with the name of the query
        being executed.

2.  **`app/controllers/table.php`:**
    *   The `runquery()` method now checks for `$_POST['running_saved_query_name']`.
    *   This name is passed to the `runQueryWithView()` method.
    *   `runQueryWithView()` now passes this name to the `table` view
        as `executed_query_name`.

3.  **`app/views/includes/header.php`:**
    *   The HTML `<title>` tag logic has been updated to include the
        `executed_query_name` if available, prepending it to the
        existing title structure (e.g., "Query: [Saved Query Name] -
        Table: [Table Name] | AppName").
    *   The main `<h1>` page heading is also updated to display the
        `executed_query_name` and its associated table when a saved
        query has been run (e.g., "Query: [Saved Query Name]
        (on table: [Table Name])"). The icon is also changed for this case.

This provides users with better context about which saved query's results they are currently viewing.