### PR TITLE
Fix: Correctly populate VQB join fields for new and edited queries

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -717,14 +717,21 @@ $('body').on('change', 'select.jointable', function () {
 
     if (value) {
         var $this = $(this);
-       // console.log("Selected table:", value); // debug
-        $.post(base + '/ajax/gettablefields', {"table": value}, function (response) {
-            var $select = $this.closest('.parent').find('select.joinfieldselected');
-         //   console.log("Fields:", response); // debug
-            $select.html(response);
-            $select.select2();
-        }).fail(function() {
-            $.jGrowl('Error loading fields!', { sticky: false, header: 'Error' });
+        var $targetSelect = $this.closest('.parent').find('select.joinfieldselected');
+       // console.log("Manual Join: Selected table:", value, "Target select:", $targetSelect);
+
+        // Use the new populateJoinFieldDropdown function
+        populateJoinFieldDropdown($targetSelect, value, null, function(success) {
+            if (success) {
+                // Optional: Trigger change on the populated select if other elements depend on its value
+                // $targetSelect.trigger('change');
+
+                // After a join table is manually selected and its fields loaded,
+                // we need to update the general field dropdowns in VQB (like joinfieldmain in other rows)
+                // to include fields from this newly selected table.
+                addTablesToDropdown();
+            }
+            // Error handling is done within populateJoinFieldDropdown
         });
     }
 });


### PR DESCRIPTION
This commit addresses an issue where the 'Joining Field' (joinfieldselected)
 pulldown was not being populated correctly in two scenarios:
1. When building a new query and adding a new join row.
2. When editing an existing query with joins (the dropdowns were empty).

The root cause was that the `gettablefields` AJAX endpoint was modified to return JSON (for use in pre-populating joins during edits), but the original `on('change', 'select.jointable')` handler still expected HTML.

Modifications:

1.  **`assets/js/custom.js` - `$('body').on('change', 'select.jointable', ...)` Handler Updated:**
    *   This handler, which triggers when a user manually selects a 'Joining Table'
        in the VQB, now uses the `populateJoinFieldDropdown` function.
    *   `populateJoinFieldDropdown` correctly handles the JSON response from
        `/ajax/gettablefields`, generates `<option>` tags, and populates the
        target 'Joining Field' (`joinfieldselected`) dropdown.
    *   After the specific 'Joining Field' dropdown is populated, `addTablesToDropdown()`
        is called. This ensures that all other relevant field selectors in the VQB
        (like the main fields list or 'Joining with Field' in other join rows)
        are updated to include fields from the newly selected/changed join table.

2.  **`assets/js/custom.js` - `populateJoinFieldDropdown()` (created in previous feature):**
    *   This function was already designed to consume JSON from `gettablefields`
        and populate a given select element, which is now used by both the edit
        pre-population logic and the manual join table change handler.

This ensures that the 'Joining Field' dropdown is consistently and correctly populated with fields from the selected 'Joining Table', whether the join row is being newly created by the user or pre-populated when editing a saved query.