### PR TITLE
Debug: Add extensive logs for VQB join table population

### DIFF
--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -261,6 +261,17 @@ $fields = $fields ?? [];
     <!-- /.modal-dialog -->
 </div>
 
+<script type="text/javascript">
+    // Store the PHP-generated table options HTML in a JS variable
+    // This should be done once, preferably in a place that's always loaded with modals.php,
+    // or directly here if modals.php is always loaded when VQB is used.
+    var allTablesOptionsHTML = <?php echo json_encode(Flight::get('tablesOptions')); ?>;
+    if (typeof allTablesOptionsHTML === 'undefined' || allTablesOptionsHTML === null) {
+        console.error("PHP 'tablesOptions' not available to JavaScript. Fallback needed or check Flight setup.");
+        allTablesOptionsHTML = '<option value=\"\">Error loading tables</option>'; // Fallback
+    }
+</script>
+
 <div id="fieldClone" class="parent" style="display: none; margin: 3px;">
     <div class="pull-left">
         <a href="#" class="remove"><i class="glyphicon glyphicon-trash glyphicon-2x" style="margin-top: 5px;"></i></a>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -179,6 +179,7 @@ $('body').on('click', '.btn-run-saved-query', function(e) {
 
 // --- Edit Saved Query Functionality ---
 $('body').on('click', '.btn-edit-saved-query', function() {
+    console.log("DEBUG: .btn-edit-saved-query - allTablesOptionsHTML content (first 200 chars):", typeof allTablesOptionsHTML !== 'undefined' ? allTablesOptionsHTML.substring(0,200) : 'NOT DEFINED');
     var queryId = $(this).data('query-id');
     var queryName = $(this).data('query-name');
     var sqlQuery = null;
@@ -219,8 +220,8 @@ $('body').on('click', '.btn-edit-saved-query', function() {
     // If opening VQB, it attempts to set context and pre-populate fields.
     if (isVisual || (visualParams && visualParams !== '')) { // Try to open in VQB if it is_visual OR if visualParams exist
         // DEBUG: Log state of #fieldCloneTable's select.jointable
-        console.log("DEBUG: Entering VQB edit path. HTML of #fieldCloneTable select.jointable BEFORE any VQB setup:", $('#fieldCloneTable').find('select.jointable').html());
-        console.log("DEBUG: Options count in #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable option').length);
+        // console.log("DEBUG: Entering VQB edit path. HTML of #fieldCloneTable select.jointable BEFORE any VQB setup:", $('#fieldCloneTable').find('select.jointable').html());
+        // console.log("DEBUG: Options count in #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable option').length);
 
         $('#visual_query_id_edit').val(queryId);
         console.log("Preparing to open Visual Query Builder for query ID:", queryId);
@@ -345,7 +346,21 @@ $('body').on('click', '.btn-edit-saved-query', function() {
                         };
                         // console.log("processNextJoin - Join Index:", joinIndex, "Def:", JSON.stringify(joinDefinition)); // DEBUG
 
+                        // Ensure the template's jointable select has fresh options before cloning for edit mode
+                        console.log("DEBUG: processNextJoin - BEFORE REPOP TEMPLATE (Join Index: " + joinIndex + ") - allTablesOptionsHTML (first 200):", typeof allTablesOptionsHTML !== 'undefined' ? allTablesOptionsHTML.substring(0,200) : 'NOT DEFINED');
+                        if (typeof allTablesOptionsHTML !== 'undefined') {
+                            $('#fieldCloneTable').find('select.jointable').html(allTablesOptionsHTML);
+                        } else {
+                            console.error("allTablesOptionsHTML is not defined. Cannot populate join table template for editing join.");
+                        }
+                        console.log("DEBUG: processNextJoin - BEFORE CLONE (Join Index: " + joinIndex + ") - HTML of #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable').html());
+                        console.log("DEBUG: processNextJoin - BEFORE CLONE (Join Index: " + joinIndex + ") - Options count for #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable option').length);
+
                         var $clone = $('#fieldCloneTable').clone().removeAttr('id').addClass('cloned-join-row');
+
+                        console.log("DEBUG: processNextJoin - AFTER CLONE - HTML of CLONED select.jointable:", $clone.find('select.jointable').html()); // DEBUG
+                        console.log("DEBUG: processNextJoin - AFTER CLONE - Options count in CLONED select.jointable:", $clone.find('select.jointable option').length); // DEBUG
+
                         // console.log("processNextJoin - Target Select for joinfieldselected:", $clone.find('select.joinfieldselected')); // DEBUG
                         $clone.find('select[name=\"jointype[]\"]').val(joinDefinition.type);
                         $clone.find('select.jointable').val(joinDefinition.table);
@@ -355,6 +370,10 @@ $('body').on('click', '.btn-edit-saved-query', function() {
                         // Append clone before populating async field dropdown
                         $('#btnJoinTable').after($clone); // Or a dedicated join container
                         $clone.find('select').select2(); // Initialize select2 for non-fieldspecific selects
+
+                        console.log("DEBUG: processNextJoin - AFTER CLONE & S2 INIT - Cloned select.jointable S2 data:", $clone.find('select.jointable').data('select2')); // DEBUG
+                        console.log("DEBUG: processNextJoin - AFTER CLONE & S2 INIT - HTML of CLONED s.jointable post-S2:", $clone.find('select.jointable').html()); // DEBUG
+
                         $clone.slideDown('fast');
 
 
@@ -720,13 +739,29 @@ $('body').on('click', '.remove', function () {
 
 // join table for visual query
 $('#btnJoinTable').click(function () {
+    console.log("DEBUG: #btnJoinTable click - allTablesOptionsHTML content (first 200 chars):", typeof allTablesOptionsHTML !== 'undefined' ? allTablesOptionsHTML.substring(0,200) : 'NOT DEFINED');
+    // Ensure the template's jointable select has fresh options before cloning
+    if (typeof allTablesOptionsHTML !== 'undefined') {
+        $('#fieldCloneTable').find('select.jointable').html(allTablesOptionsHTML);
+    } else {
+        console.error("allTablesOptionsHTML is not defined. Cannot populate join table template for new join.");
+    }
+    console.log("DEBUG: btnJoinTable Click - BEFORE CLONE - HTML of #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable').html());
+    console.log("DEBUG: btnJoinTable Click - BEFORE CLONE - Options count for #fieldCloneTable select.jointable:", $('#fieldCloneTable').find('select.jointable option').length);
+
     var $clone = $('#fieldCloneTable').clone();
+    console.log("DEBUG: btnJoinTable Click - AFTER CLONE - HTML of CLONED select.jointable:", $clone.find('select.jointable').html());
+    console.log("DEBUG: btnJoinTable Click - AFTER CLONE - Options count in CLONED select.jointable:", $clone.find('select.jointable option').length);
+
     $(this).after($clone);
     $clone.slideDown('fast');
 
     $clone.find('.select2-container').remove();
     $clone.find('.joinfieldselected').empty();
     $clone.find('select').select2();
+
+    console.log("DEBUG: btnJoinTable Click - AFTER CLONE & S2 INIT - Cloned select.jointable S2 data:", $clone.find('select.jointable').data('select2'));
+    console.log("DEBUG: btnJoinTable Click - AFTER CLONE & S2 INIT - HTML of CLONED s.jointable post-S2:", $clone.find('select.jointable').html());
 
     $('#addjoinedtablefields').slideDown('fast');
 });


### PR DESCRIPTION
This commit adds a more comprehensive set of console.log statements to `assets/js/custom.js` to further diagnose issues with the 'Joining Table' (`select.jointable`) dropdown in the Visual Query Builder.

Logs are added to trace:
- The content of the `allTablesOptionsHTML` global variable at various points.
- The state (HTML content and option count) of the `select.jointable` dropdown within the `#fieldCloneTable` template immediately before it's cloned. This is done for both the manual join creation path (`#btnJoinTable` click) and the saved query edit path (`processNextJoin` function).
- The state of the `select.jointable` dropdown within the *cloned* element immediately after cloning.
- The state of the cloned `select.jointable` (including Select2 data) after Select2 is initialized on the clone.

These detailed logs aim to pinpoint exactly when and why the 'Joining Table' dropdown might be losing its options, particularly in the scenario of editing an existing saved query.