### PR TITLE
Fix: Ensure 'Joining Table' dropdown is populated in VQB edit mode

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -374,6 +374,30 @@ class Table
         $exec_time_row = array();
         $records = '';
 
+        // Ensure tablesOptions is available for the view context
+        // This is the same logic as in index.php for initial setup
+        // Consider refactoring this into a helper or a Flight before-render hook if used more broadly
+        if (!Flight::get('tablesOptions') || Flight::get('tablesOptions') === '') {
+            $_db = Flight::get('db');
+            try {
+                $allTablesStmt = $_db->query('SHOW TABLES');
+                $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
+                $tableNamesForOptions = [];
+                foreach ($allTablesResult as $row) {
+                    $tableNamesForOptions[] = $row[0];
+                }
+                // The 'true' for $prependEmptyOption in getOptions adds a default empty option.
+                // The text for this is "Joining Key Field" by default in getOptions.
+                // If "Joining Table" is preferred, getOptions would need modification or a new param.
+                $tablesOptionsHtmlString = getOptions($tableNamesForOptions, true);
+                Flight::set('tablesOptions', $tablesOptionsHtmlString ? $tablesOptionsHtmlString : '');
+            } catch (PDOException $e) {
+                error_log("Error fetching table list for tablesOptions in runQueryWithView: " . $e->getMessage());
+                Flight::set('tablesOptions', '<option value="">Error loading tables</option>');
+            }
+        }
+
+
         try {
             // turn on query profiling
             Flight::get('db')->query('SET profiling = 1;');

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -265,10 +265,12 @@ $fields = $fields ?? [];
     // Store the PHP-generated table options HTML in a JS variable
     // This should be done once, preferably in a place that's always loaded with modals.php,
     // or directly here if modals.php is always loaded when VQB is used.
-    var allTablesOptionsHTML = <?php echo json_encode(Flight::get('tablesOptions')); ?>;
-    if (typeof allTablesOptionsHTML === 'undefined' || allTablesOptionsHTML === null) {
-        console.error("PHP 'tablesOptions' not available to JavaScript. Fallback needed or check Flight setup.");
-        allTablesOptionsHTML = '<option value=\"\">Error loading tables</option>'; // Fallback
+    var allTablesOptionsHTML = <?php echo json_encode(Flight::get('tablesOptions') ?? '<option value=\"\">No tables found</option>'); ?>;
+    // Check if json_encode resulted in an empty string literal "''" (if Flight::get returned empty string)
+    // or if it's the explicit "null" string from json_encode(null)
+    if (allTablesOptionsHTML === '""' || allTablesOptionsHTML === 'null' || allTablesOptionsHTML.indexOf('<option') === -1) {
+        allTablesOptionsHTML = '<option value=\"\">No tables available</option>';
+        console.warn("PHP 'tablesOptions' was empty or invalid. Using fallback for allTablesOptionsHTML.", <?php echo json_encode(Flight::get('tablesOptions')); ?>);
     }
 </script>
 


### PR DESCRIPTION
This commit fixes an issue where the 'Joining Table' (select.jointable)
 dropdown in the Visual Query Builder (VQB) was empty when editing an
 existing saved query, preventing users from adding new joins or seeing
 the correct table in pre-populated join rows.

The root cause was that the JavaScript variable `allTablesOptionsHTML` (which
 holds the HTML for all table options) was not being correctly initialized
 when the VQB modal was rendered in an 'edit' context (typically after a page
 re-render post-query execution), because `Flight::get('tablesOptions')` was
 unavailable or empty in that specific PHP rendering pass for `modals.php`.

Changes:

1.  **`app/controllers/table.php` (`runQueryWithView` method):**
    *   Added logic to explicitly fetch all table names and generate the
        HTML options string for tables (using the global `getOptions()` helper).
    *   This HTML string is then set using `Flight::set('tablesOptions', ...)`
        before the `table.php` view (which includes `modals.php`) is rendered.
        This ensures `Flight::get('tablesOptions')` is always populated with the
        necessary data when `modals.php` initializes `allTablesOptionsHTML`.

2.  **`app/views/includes/modals.php`:**
    *   The JavaScript block that initializes the global `allTablesOptionsHTML`
        variable from `<?php echo json_encode(Flight::get('tablesOptions') ...); ?>`
        was made more robust with PHP null coalescing and a JS fallback to ensure
        it always results in a usable (even if minimal) HTML string for the options.

3.  **`assets/js/custom.js`:**
    *   In both the `$('#btnJoinTable').click()` handler (for manually adding a new join)
        and in the `processNextJoin` function (within the `.btn-edit-saved-query`
        handler, for pre-populating joins from `visual_params` during an edit):
        The line `$('#fieldCloneTable').find('select.jointable').html(allTablesOptionsHTML);`
        is now executed *before* `$('#fieldCloneTable').clone()` is called.
        This ensures the hidden template for join rows is always refreshed with the
        latest, complete list of table options before it's cloned.
    *   Debugging `console.log` statements related to this issue have been commented out.

These changes ensure that the 'Joining Table' dropdown in VQB join rows is correctly and consistently populated with all available database tables, for both newly added joins and when editing existing saved queries.