### PR TITLE
Fix: Ensure VQB 'Joining Table' dropdown is always populated

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -76,23 +76,25 @@ class Table
 
         $records = Presenter::listTableData($records, $fieldTypes);
 
-        // Ensure tablesOptions is available for the view context, similar to runQueryWithView
-        // This is for direct table views (not after a query run)
-        if (!Flight::get('tablesOptions') || Flight::get('tablesOptions') === '') {
-            $_db = Flight::get('db');
-            try {
-                $allTablesStmt = $_db->query('SHOW TABLES');
-                $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
-                $tableNamesForOptions = [];
-                foreach ($allTablesResult as $row) {
-                    $tableNamesForOptions[] = $row[0];
-                }
-                $tablesOptionsHtmlString = getOptions($tableNamesForOptions, true);
-                Flight::set('tablesOptions', $tablesOptionsHtmlString ? $tablesOptionsHtmlString : '');
-            } catch (PDOException $e) {
-                error_log("Error fetching table list for tablesOptions in Table::index: " . $e->getMessage());
-                Flight::set('tablesOptions', '<option value="">Error loading tables</option>');
+        // Generate tablesOptionsHTML directly for this view rendering
+        $_db = Flight::get('db');
+        $tablesOptionsHtmlForView = '<option value="">Error loading tables (Controller Default)</option>'; // Default
+        try {
+            $allTablesStmt = $_db->query('SHOW TABLES');
+            $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
+            $tableNamesForOptions = [];
+            foreach ($allTablesResult as $row) {
+                $tableNamesForOptions[] = $row[0];
             }
+            $currentTablesOptions = getOptions($tableNamesForOptions, true); // true for "Choose Table"
+            if (!empty(trim($currentTablesOptions)) && strpos($currentTablesOptions, '<option') !== false) {
+                $tablesOptionsHtmlForView = $currentTablesOptions;
+            } else { // Handles case where getOptions might return only the default or empty
+                $tablesOptionsHtmlForView = '<option value="">No tables found in DB</option>';
+            }
+        } catch (PDOException $e) {
+            error_log("Error fetching table list for view_tables_options_html in Table::index: " . $e->getMessage());
+            // $tablesOptionsHtmlForView remains as "Error loading tables..."
         }
 
         Flight::render(
@@ -104,9 +106,7 @@ class Table
               'table_data' => $records,
               'query' => SqlFormatter::format(ORM::get_last_query(ORM::DEFAULT_CONNECTION)),
               'timetaken' => $exec_time_row[0][1],
-              // Pass the globally set tablesOptions to the view, so modals.php can access it
-              // This ensures it's available even when table.php is rendered by Table::index()
-              'view_tables_options_html' => Flight::get('tablesOptions')
+              'view_tables_options_html' => $tablesOptionsHtmlForView
            )
         );
     }
@@ -394,29 +394,26 @@ class Table
         $exec_time_row = array();
         $records = '';
 
-        // Ensure tablesOptions is available for the view context
-        // This is the same logic as in index.php for initial setup
-        // Consider refactoring this into a helper or a Flight before-render hook if used more broadly
-        if (!Flight::get('tablesOptions') || Flight::get('tablesOptions') === '') {
-            $_db = Flight::get('db');
-            try {
-                $allTablesStmt = $_db->query('SHOW TABLES');
-                $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
-                $tableNamesForOptions = [];
-                foreach ($allTablesResult as $row) {
-                    $tableNamesForOptions[] = $row[0];
-                }
-                // The 'true' for $prependEmptyOption in getOptions adds a default empty option.
-                // The text for this is "Joining Key Field" by default in getOptions.
-                // If "Joining Table" is preferred, getOptions would need modification or a new param.
-                $tablesOptionsHtmlString = getOptions($tableNamesForOptions, true);
-                Flight::set('tablesOptions', $tablesOptionsHtmlString ? $tablesOptionsHtmlString : '');
-            } catch (PDOException $e) {
-                error_log("Error fetching table list for tablesOptions in runQueryWithView: " . $e->getMessage());
-                Flight::set('tablesOptions', '<option value="">Error loading tables</option>');
+        // Ensure tablesOptions is available for the view context by generating it directly
+        $_db = Flight::get('db');
+        $tablesOptionsHtmlForView = '<option value="">Error loading tables (Controller Default)</option>'; // Default
+        try {
+            $allTablesStmt = $_db->query('SHOW TABLES');
+            $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
+            $tableNamesForOptions = [];
+            foreach ($allTablesResult as $row) {
+                $tableNamesForOptions[] = $row[0];
             }
+            $currentTablesOptions = getOptions($tableNamesForOptions, true); // true for "Choose Table"
+            if (!empty(trim($currentTablesOptions)) && strpos($currentTablesOptions, '<option') !== false) {
+                $tablesOptionsHtmlForView = $currentTablesOptions;
+            } else { // Handles case where getOptions might return only the default or empty
+                $tablesOptionsHtmlForView = '<option value="">No tables found in DB</option>';
+            }
+        } catch (PDOException $e) {
+            error_log("Error fetching table list for view_tables_options_html in runQueryWithView: " . $e->getMessage());
+            // $tablesOptionsHtmlForView remains as "Error loading tables..."
         }
-
 
         try {
             // turn on query profiling


### PR DESCRIPTION
This commit fixes an issue where the 'Joining Table' (select.jointable)
 dropdown in the Visual Query Builder (VQB) was empty when editing an
 existing saved query. This was due to the JavaScript variable
 `allTablesOptionsHTML` (holding all table options as HTML) not being
 correctly initialized when the VQB modal was rendered in an 'edit' context.

Modifications:

1.  **`app/controllers/table.php` (`index()` and `runQueryWithView()` methods):**
    *   Both methods now unconditionally fetch all available table names from the
        database and generate an HTML string of `<option>` tags using the
        `getOptions()` helper. This generated HTML string is stored in a local
        variable `$tablesOptionsHtmlForView`.
    *   `$tablesOptionsHtmlForView` is then explicitly passed to the `Flight::render('table', ...)`
        call with the key `view_tables_options_html`.
        This ensures the view always receives the necessary options data directly
        from the controller, regardless of previous Flight variable states.

2.  **`app/views/includes/modals.php`:**
    *   The JavaScript block that initializes the global `allTablesOptionsHTML`
        variable now uses `<?php echo json_encode($view_tables_options_html ?? ...); ?>`,
        directly consuming the variable passed from the controller.
    *   Fallback logic in JavaScript for `allTablesOptionsHTML` was enhanced to
        better detect invalid or empty option strings.

3.  **`assets/js/custom.js`:**
    *   In both the `$('#btnJoinTable').click()` handler (for manually adding a
        new join) and in the `processNextJoin` function (within the
        `.btn-edit-saved-query` handler for pre-populating joins):
        The line `$('#fieldCloneTable').find('select.jointable').html(allTablesOptionsHTML);`
        is executed *before* `$('#fieldCloneTable').clone()` is called.
        This refreshes the hidden template's 'Joining Table' dropdown with the
        correctly initialized `allTablesOptionsHTML` before it's cloned.
    *   Extensive debugging `console.log` statements (added in a previous step on this
        branch) remain in place for user testing and verification.

4.  **`func.php` (`getOptions()` function):**
    *   The default placeholder text for the prepended empty option was changed
        from "Joining Key Field" to "Choose Table" for better context.

These changes ensure that the 'Joining Table' dropdown in VQB join rows is correctly and consistently populated with all available database tables in all scenarios (new query, editing query with joins, editing query and then adding a new join).