### PR TITLE
Feat: Store and use primaryTable in visual query parameters

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -805,9 +805,28 @@ $('body').on('click', '#btnShowSaveQueryModal', function() {
     $('#query_name_save').val(''); // Always clear name for a new save
 
     // For saving visual query params
-    var visualParamsJson = $('#current_visual_params').val();
-    if (visualParamsJson && visualParamsJson !== '') {
-        $('#modal-save-query').data('visual-params', visualParamsJson);
+    var visualParamsJsonString = $('#current_visual_params').val();
+    if (visualParamsJsonString && visualParamsJsonString !== '') {
+        try {
+            var visualParamsObject = JSON.parse(visualParamsJsonString);
+            // Add the primaryTable information using the global __table variable
+            // __table is set in app/views/table.php
+            if (typeof __table !== 'undefined' && __table) {
+                visualParamsObject.primaryTable = __table;
+            } else {
+                console.warn('__table variable is not defined. Cannot add primaryTable to visual_params for saving.');
+                // Potentially, you could prevent saving here or notify the user,
+                // but for now, we'll allow saving without it if __table is missing,
+                // though editing might fail later as per the original issue.
+            }
+            // Store the modified object (as a string) in the modal's data
+            $('#modal-save-query').data('visual-params', JSON.stringify(visualParamsObject));
+            console.log('Visual params for save:', JSON.stringify(visualParamsObject));
+        } catch (e) {
+            console.error('Error parsing visual_params_json or adding primaryTable:', e);
+            // If parsing fails, store the original string, though it's likely an issue.
+            $('#modal-save-query').data('visual-params', visualParamsJsonString);
+        }
     } else {
         $('#modal-save-query').removeData('visual-params'); // Ensure it's clear if no params
     }


### PR DESCRIPTION
This commit addresses an issue where editing a saved visual query could fail because the primary table context (`__table` JavaScript variable) was not being correctly initialized. This was due to the `visual_params` JSON not storing the original primary table of the query.

Changes:
- Modified `assets/js/custom.js` in the `btnShowSaveQueryModal` click handler:
  - When preparing visual query parameters for saving, the script now parses the existing JSON parameters from `#current_visual_params`.
  - It adds a `primaryTable` key to this parsed object, setting its value from the global `__table` JavaScript variable (which reflects the current table context when the query was run).
  - The modified object (now including `primaryTable`) is then re-stringified and passed to the save mechanism.

This ensures that when a visual query is saved, its primary table is recorded. When the query is later edited, the `btn-edit-saved-query` logic can correctly extract `primaryTable` from the loaded `visual_params` and set the `__table` context, allowing the visual query builder to load and populate correctly.