### PR TITLE
Refactor: Provide table options globally for VQB

### DIFF
--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -262,12 +262,12 @@ $fields = $fields ?? [];
 </div>
 
 <script type="text/javascript">
-    // Store the PHP-generated table options HTML in a JS variable
-    // This uses the $view_tables_options_html variable passed directly from the controller
-    var allTablesOptionsHTML = <?php echo json_encode($view_tables_options_html ?? '<option value=\"\">No tables found (PHP Fallback)</option>'); ?>;
+    // Store the globally generated table options HTML (from Flight::get('masterTableOptionsHTML')) in a JS variable
+    var allTablesOptionsHTML = <?php echo json_encode(Flight::get('masterTableOptionsHTML') ?? '<option value=\"\">No tables available (Global Fallback)</option>'); ?>;
     if (typeof allTablesOptionsHTML !== 'string' || allTablesOptionsHTML.trim() === '' || allTablesOptionsHTML.indexOf('<option') === -1) {
+        // This JS fallback should ideally not be hit if masterTableOptionsHTML is always populated in index.php
         allTablesOptionsHTML = '<option value=\"\">No tables available (JS Fallback)</option>';
-        // console.warn("View variable 'view_tables_options_html' was empty or invalid. Using JS fallback.", <?php echo json_encode($view_tables_options_html ?? 'PHP var $view_tables_options_html not set for modals.php'); ?>);
+        console.warn("masterTableOptionsHTML was empty or invalid from Flight::get. Using JS fallback.");
     }
 </script>
 
@@ -398,8 +398,7 @@ $fields = $fields ?? [];
     </div>
     <div class="pull-left">
         <select name="jointable[]" class="jointable form-control" style="width: 160px;">
-            <option value="">Joining Table</option>
-            <?php echo Flight::get('tablesOptions'); ?>
+            <?php echo Flight::get('masterTableOptionsHTML') ?? '<option value="">No tables available</option>'; ?>
         </select>
     </div>
     <div class="pull-left" style="margin: 3px;">

--- a/index.php
+++ b/index.php
@@ -98,6 +98,11 @@ $stmt = $db->query("SHOW TABLES FROM " . Flight::get('dbname'));
 $data = $stmt->fetchAll(PDO::FETCH_NUM);
 $data = arrayFlatten($data);
 
+// Generate HTML options for all tables to be used globally, especially in modals
+// The `true` for getOptions prepends a "Choose Table" or similar default option.
+$masterTableOptionsHTML = getOptions($data, true);
+Flight::set('masterTableOptionsHTML', $masterTableOptionsHTML);
+
 // create table names json file
 $json = array();
 foreach ($data as $datakey => $datavalue) {


### PR DESCRIPTION
This commit ensures that the list of database tables (as HTML options) is always available to the Visual Query Builder (VQB) modal, regardless of the page from which it's accessed (e.g., dashboard or table view). This resolves issues where the 'Join Table' dropdown in the VQB would show a fallback message like 'No Tables Found'.

Changes:
1.  **`index.php`**: Modified to fetch all table names early in the script's execution (after DB connection and `func.php` are loaded). It then uses `getOptions(\$data, true)` to generate an HTML string of all table options (including a default 'Choose Table' option) and stores this in a new global Flight variable: `Flight::set('masterTableOptionsHTML', ...)`.

2.  **`app/views/includes/modals.php`**:
    -   The JavaScript variable `allTablesOptionsHTML` is now initialized
        directly from `Flight::get('masterTableOptionsHTML')`.
    -   The `<select class="jointable">` dropdown within the `#fieldCloneTable`
        template is also populated directly using
        `Flight::get('masterTableOptionsHTML')`.
        This ensures both the JS context and the HTML template have the
        correct, full list of tables from page load.

This approach centralizes the fetching and preparation of table options, making them reliably available and simplifying the logic in `custom.js` which previously had to handle cases where these options might be missing.