### PR TITLE
Fix: Set VQB form action dynamically to correct table endpoint

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -207,6 +207,18 @@ $('body').on('click', '.btn-edit-saved-query', function() {
             // Set the primary table
             __table = parsedParams.primaryTable || '';
             $('#modal-visual-query .vqb-table-name').text('Table: ' + (__table ? __table.toUpperCase() : 'UNKNOWN'));
+
+            // Dynamically set the form action for the VQB modal
+            if (__table) {
+                var formActionUrl = base + '/table/' + __table;
+                $('#modal-visual-query form').attr('action', formActionUrl);
+                console.log("VQB form action set to:", formActionUrl);
+            } else {
+                // This case should ideally not happen if primaryTable is always saved and present
+                console.error("VQB: __table is not defined, cannot set form action accurately. Form will submit to current page.");
+                // Fallback to current page if __table is missing, which is the default for action=""
+                $('#modal-visual-query form').attr('action', '');
+            }
             
             // Clear existing joins
             $('#modal-visual-query .cloned-join-row').remove();


### PR DESCRIPTION
When running a query from the Visual Query Builder (VQB) modal, especially when the modal was opened from a non-table page (e.g., the dashboard by editing a saved query), the form would submit to the current page's URL (e.g., '/home'). This caused a 404 error as the '/home' route is not equipped to handle query execution POST requests.

This commit modifies `assets/js/custom.js` within the `.btn-edit-saved-query` handler:
- When the VQB modal is initialized for editing a saved query, the `action` attribute of the modal's form (`#modal-visual-query form`) is now dynamically set.
- The `action` is constructed using the application's `base` URL and the `__table` variable (which holds the primary table name of the query being edited, derived from `parsedParams.primaryTable`). The format is `base + '/table/' + __table`.

This ensures that the VQB form always POSTs to the correct endpoint (e.g., `/table/actual_primary_table_name`), allowing `Table::runquery` to process the query in the appropriate table context, regardless of the page from which the VQB modal was opened.