### PR TITLE
Fix: Ensure selected fields/aliases are submitted for VQB 'Run Query'

### DIFF
--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -144,10 +144,12 @@ $fields = $fields ?? [];
     <div class="row">
         <div class="col-xs-5">
             <strong class="selected-field-name-display"></strong>
-            <input type="hidden" class="selected-field-name-hidden" /> <!-- To store original field name -->
+            <!-- Name attribute will be dynamically indexed by JavaScript e.g., fields[0][field] -->
+            <input type="hidden" class="selected-field-name-hidden" name="fields[0][field]" />
         </div>
         <div class="col-xs-5">
-            <input type="text" class="form-control input-sm field-alias-input" placeholder="Optional Alias">
+            <!-- Name attribute will be dynamically indexed by JavaScript e.g., fields[0][alias] -->
+            <input type="text" class="form-control input-sm field-alias-input" name="fields[0][alias]" placeholder="Optional Alias">
         </div>
         <div class="col-xs-2 text-right">
             <button type="button" class="btn btn-xs btn-danger remove-field-alias-row" title="Remove Field">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -450,11 +450,21 @@ $('body').on('click', '#btnAddFieldsToQueryList', function() {
             });
 
             if (!isAlreadyAdded) {
+                var currentIndex = $container.find('.parent:visible').length; // Get current number of rows to use as next index
+
                 var $clone = $template.clone().removeAttr('id').show();
                 var fieldText = $sourceSelect.find('option[value="' + fieldValue + '"]').text(); // Get text for display
+
                 $clone.find('.selected-field-name-display').text(fieldText || fieldValue);
-                $clone.find('.selected-field-name-hidden').val(fieldValue);
-                $clone.find('.field-alias-input').val(''); // Clear any previous alias from template
+
+                $clone.find('.selected-field-name-hidden')
+                      .val(fieldValue)
+                      .attr('name', 'fields[' + currentIndex + '][field]');
+
+                $clone.find('.field-alias-input')
+                      .val('') // Clear any previous alias from template
+                      .attr('name', 'fields[' + currentIndex + '][alias]');
+
                 $container.append($clone);
             }
         });


### PR DESCRIPTION
Previously, when running a query directly from the Visual Query Builder (VQB) using the 'Run Query (from editor)' button, the selected non-aggregated fields (and their aliases from the new UI) were not being correctly submitted to the server. This resulted in the server-side logic defaulting to `SELECT *` because the `$_POST['fields']` array was empty or not in the expected format.

This was due to the dynamically created input elements for selected fields and aliases in the `#selectedFieldsContainer` lacking the necessary `name` attributes for standard form serialization.

This commit addresses the issue by:

1.  **Modifying `app/views/includes/modals.php` (`#fieldAliasRowTemplate`):**
    -   The hidden input for the field name (`class="selected-field-name-hidden"`)
        now has a base `name="fields[0][field]"`.
    -   The text input for the alias (`class="field-alias-input"`) now has a
        base `name="fields[0][alias]"`.
    (The `[0]` index is a placeholder to be updated by JavaScript).

2.  **Modifying `assets/js/custom.js` (`#btnAddFieldsToQueryList` handler):**
    -   When a new field/alias row is cloned from `#fieldAliasRowTemplate` and
        appended to `#selectedFieldsContainer`:
        -   The JavaScript now calculates the correct sequential index for the new row.
        -   It dynamically updates the `name` attributes of the `.selected-field-name-hidden`
            and `.field-alias-input` elements within the cloned row to use this index
            (e.g., `fields[1][field]`, `fields[1][alias]`, etc.).

With these changes, when the VQB form is submitted via the 'Run Query (from editor)' button, the browser will correctly serialize the selected fields and their aliases into a `$_POST['fields']` array of associative arrays. This is the format that the existing `Table::generateSqlFromVisualParams` method expects, allowing it to generate the correct SQL SELECT clause with the user-specified fields and aliases.