### PR TITLE
Fix: Prevent non-aggregated fields from populating Group By

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -285,9 +285,9 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
     // Load options for all field dropdowns and then populate other VQB elements
     addTablesToDropdown(function(success) {
         if (success) {
-            // Non-aggregated fields
+            // Non-aggregated fields - targeting specifically by name to avoid conflict with other selects that might have '.fields' class
             if (visualParamsObj.fields && Array.isArray(visualParamsObj.fields)) {
-                $modal.find('select.fields').val(visualParamsObj.fields).trigger('change.select2');
+                $modal.find('select[name="fields[]"]').val(visualParamsObj.fields).trigger('change.select2');
             }
 
             // TODO: Populate WHERE conditions (dynamic rows)


### PR DESCRIPTION
Previously, when editing a saved visual query, setting the values for the 'Select Non-Aggregated Fields' dropdown could unintentionally also set values for the 'Group By Fields' dropdown (and potentially other dropdowns). This was because the jQuery selector used (`select.fields`) was too broad and targeted multiple select elements that shared the generic '.fields' class. This would lead to unwanted fields appearing in the GROUP BY clause upon saving.

This commit modifies `assets/js/custom.js` within the `openVisualQueryBuilderModal` function:
- The jQuery selector for setting the values of the 'Select Non-Aggregated Fields' dropdown has been changed from `$modal.find('select.fields')` to the more specific attribute selector `$modal.find('select[name="fields[]"]')`.

This ensures that only the intended non-aggregated fields dropdown is affected when its saved values are applied, preventing the cross-population of other VQB field selectors like 'Group By Fields'.