### PR TITLE
Fix: Correct timing for setting saved joinfieldp value in VQB

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -273,12 +273,18 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
                 visualParamsObj.jointable[idx],
                 visualParamsObj.joinfield[idx],
                 function(success) {
-                    if (success) {
-                        $clone.find('select.joinfieldmain').val(visualParamsObj.joinfieldp[idx]);
-                        $clone.find('select').trigger('change.select2');
-                    }
+                    // if (success) {
+                    //     // Value for joinfieldmain will be set after addTablesToDropdown completes for all fields
+                    // }
+                    // Still trigger change for the joinfieldselected that was just populated
+                    $clone.find('select.joinfieldselected').trigger('change.select2');
                 }
             );
+            // Store the target value for joinfieldp (primary table's field) on the element itself
+            // It will be applied after addTablesToDropdown finishes loading all options.
+            if (visualParamsObj.joinfieldp && visualParamsObj.joinfieldp[idx]) {
+                $clone.find('select.joinfieldmain').data('saved-value', visualParamsObj.joinfieldp[idx]);
+            }
         });
     }
 
@@ -289,6 +295,17 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
             if (visualParamsObj.fields && Array.isArray(visualParamsObj.fields)) {
                 $modal.find('select.fields').val(visualParamsObj.fields).trigger('change.select2');
             }
+
+            // After all options are loaded by addTablesToDropdown,
+            // now set the saved values for joinfieldmain in each cloned join row.
+            $modal.find('.cloned-join-row').each(function() {
+                var $clonedJoinRow = $(this);
+                var $joinfieldmainSelect = $clonedJoinRow.find('select.joinfieldmain');
+                var savedValue = $joinfieldmainSelect.data('saved-value');
+                if (savedValue) {
+                    $joinfieldmainSelect.val(savedValue).trigger('change.select2');
+                }
+            });
 
             // TODO: Populate WHERE conditions (dynamic rows)
             // Iterate visualParamsObj.fname, fvalue, ftype. For each, clone #fieldClone, set values, append.


### PR DESCRIPTION
Previously, when editing a saved visual query with joins, the 'Joining with Field' (name: `joinfieldp[]`, class: `joinfieldmain`) dropdown in a join row might display an incorrect value (e.g., the first field in the list instead of the actual saved field). This was due to a timing issue:

The value for `joinfieldp[]` was being set within the success callback of `populateJoinFieldDropdown` (which loads fields for the *other* dropdown in the join row, `joinfield[]`). However, the *options* for `joinfieldp[]` (fields from the primary table and other already joined tables) are populated by a separate, later, asynchronous call to `addTablesToDropdown`. If `addTablesToDropdown` hadn't finished populating the options for `joinfieldp[]` by the time its value was set, the selection would fail or default incorrectly.

This commit modifies `openVisualQueryBuilderModal` in `assets/js/custom.js`:
1.  In the loop that creates join rows (`visualParamsObj.jointype.forEach`):
    -   The line that directly set the value of `select.joinfieldmain` within
        the `populateJoinFieldDropdown` callback has been removed.
    -   Instead, the target saved value for `joinfieldp[]` (from
        `visualParamsObj.joinfieldp[idx]`) is now stored as a jQuery data
        attribute (`data('saved-value', ...)`) on the `select.joinfieldmain`
        element of the cloned join row.

2.  In the main `addTablesToDropdown(function(success) { ... })` callback (after all dropdown options, including for `select.joinfieldmain` in cloned rows, have been populated):
    -   A new loop iterates through each `.cloned-join-row`.
    -   It retrieves the `saved-value` from the `select.joinfieldmain` data.
    -   If a value exists, it's applied using `.val(savedValue)` and
        `.trigger('change.select2')` to update the Select2 UI.

This ensures that the selected value for `joinfieldp[]` is set only after its corresponding `<option>` tags are guaranteed to be present, resolving the incorrect display and subsequent save issue.