### PR TITLE
feat: Add table formatting for column titles (Phase 1)

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -293,4 +293,98 @@ class Ajax
 
         echo json_encode($response);
     }
+
+    public static function saveTableFormatting()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
+
+        $query_id = $_POST['query_id'] ?? null;
+        $table_formatting_json = $_POST['table_formatting'] ?? null;
+
+        if (empty($query_id) || !is_numeric($query_id)) {
+            $response['message'] = 'Invalid Query ID provided.';
+            echo json_encode($response);
+            return;
+        }
+
+        // Validate if table_formatting_json is a valid JSON string or null
+        if (!is_null($table_formatting_json)) {
+            json_decode($table_formatting_json);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $response['message'] = 'Invalid JSON string provided for table formatting.';
+                echo json_encode($response);
+                return;
+            }
+        } else {
+            // Allow saving null to clear formatting
+            $table_formatting_json = null;
+        }
+
+        try {
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+            if ($saved_query) {
+                $saved_query->table_formatting = $table_formatting_json;
+                if ($saved_query->save()) {
+                    $response['status'] = 'success';
+                    $response['message'] = 'Table formatting saved successfully!';
+                } else {
+                    $response['message'] = 'Failed to save table formatting to the database.';
+                }
+            } else {
+                $response['message'] = 'Query not found. Cannot save formatting.';
+            }
+        } catch (PDOException $e) {
+            error_log("Error saving table formatting: " . $e->getMessage());
+            $response['message'] = 'Database error: Could not save table formatting. ' . $e->getMessage();
+        } catch (Exception $e) {
+            error_log("General error saving table formatting: " . $e->getMessage());
+            $response['message'] = 'An unexpected error occurred: ' . $e->getMessage();
+        }
+
+        echo json_encode($response);
+    }
+
+    public static function getTableFormatting($query_id)
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.', 'table_formatting' => null];
+
+        if (empty($query_id) || !is_numeric($query_id)) {
+            $response['message'] = 'Invalid Query ID provided.';
+            echo json_encode($response);
+            return;
+        }
+
+        try {
+            $saved_query = ORM::for_table('saved_queries')
+                            ->select('table_formatting')
+                            ->find_one($query_id);
+
+            if ($saved_query) {
+                $response['status'] = 'success';
+                $response['message'] = 'Table formatting retrieved successfully.';
+                $response['table_formatting'] = $saved_query->table_formatting ? json_decode($saved_query->table_formatting, true) : null;
+                if (json_last_error() !== JSON_ERROR_NONE && !is_null($saved_query->table_formatting)) {
+                    // If there was an error decoding, but it wasn't null, log it and return null for formatting
+                    error_log("Error decoding table_formatting JSON for query_id: $query_id. JSON: " . $saved_query->table_formatting);
+                    $response['table_formatting'] = null;
+                    $response['message'] = 'Formatting data is corrupted. Please save again.';
+                    // $response['status'] could be set to 'error' or keep 'success' but with null data.
+                }
+            } else {
+                $response['message'] = 'Query not found.';
+                // Status remains 'error' or could be 'success' with null formatting if not finding is not an error for this call
+            }
+        } catch (PDOException $e) {
+            error_log("Error fetching table formatting: " . $e->getMessage());
+            $response['message'] = 'Database error: Could not retrieve table formatting. ' . $e->getMessage();
+        } catch (Exception $e) {
+            error_log("General error fetching table formatting: " . $e->getMessage());
+            $response['message'] = 'An unexpected error occurred: ' . $e->getMessage();
+        }
+
+        echo json_encode($response);
+    }
 }

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -426,21 +426,75 @@ class Table
 //print_r($data);
             if (!empty($data) && isset($data[0])) {
                 $header = array_keys($data[0]);
-                $_SESSION['tableData'] = array($header);  // Header row as array
+
+                // --- Apply Table Formatting ---
+                // Check if we are running a saved query that might have formatting
+                $current_query_id_for_formatting = null;
+                if ($running_saved_query_name) { // If a saved query by name was run
+                    // Try to get its ID. This part might be slightly redundant if executed_query_id is already reliably set later
+                    // but good to have a direct path if possible.
+                    $temp_saved_query = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
+                    if ($temp_saved_query) {
+                        $current_query_id_for_formatting = $temp_saved_query->id;
+                    }
+                }
+                // If visual_query_params are present, and they contain an 'executed_query_id', that's another source
+                // This is primarily for when "Edit Query" is used from a saved query.
+                // For direct "Run Query" from dashboard, running_saved_query_name is the primary source.
+                // The logic to get executed_query_id for view_data later is more comprehensive.
+                // For applying formatting, we need the ID *before* Presenter::listTableData.
+
+                // Let's refine how we get the query_id for formatting, using the same logic as for view_data population
+                $query_id_for_formatting_lookup = null;
+                if (isset($_POST['executed_query_id']) && !empty($_POST['executed_query_id'])) { // If explicitly passed (e.g. during an edit flow)
+                     $query_id_for_formatting_lookup = $_POST['executed_query_id'];
+                } else if ($running_saved_query_name) { // If a saved query was run by name
+                    $sq_details = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
+                    if ($sq_details) $query_id_for_formatting_lookup = $sq_details->id;
+                }
+                // $_POST['query_id'] might also be relevant if a query is saved and run immediately.
+                // However, the current flow for "Save" doesn't immediately run and apply formatting.
+                // Formatting is applied when a *saved* query is run.
+
+                if ($query_id_for_formatting_lookup) {
+                    $query_with_formatting = ORM::for_table('saved_queries')->find_one($query_id_for_formatting_lookup);
+                    if ($query_with_formatting && !empty($query_with_formatting->table_formatting)) {
+                        try {
+                            $formatting_rules = json_decode($query_with_formatting->table_formatting, true);
+                            if (json_last_error() === JSON_ERROR_NONE && isset($formatting_rules['column_titles'])) {
+                                $new_header = [];
+                                foreach ($header as $original_col_name) {
+                                    // Use the new title if defined and not empty, otherwise use original
+                                    $new_header[] = (!empty($formatting_rules['column_titles'][$original_col_name])) ? $formatting_rules['column_titles'][$original_col_name] : $original_col_name;
+                                }
+                                $header = $new_header; // Replace original header with formatted one
+                            }
+                        } catch (Exception $e) {
+                            error_log("Error decoding table formatting JSON: " . $e->getMessage());
+                        }
+                    }
+                }
+                // --- End Apply Table Formatting ---
+
+                $_SESSION['tableData'] = array($header);  // Header row as array, now potentially with custom titles
 
                 foreach ($data as $row) {
                     $_SESSION['tableData'][] = array_values($row);  // Data rows as arrays
                 }
             } else {
                 // Handle empty result set for session data
+                $header = []; // No header if no data
                 $_SESSION['tableData'] = array(); // Store empty data or a specific format for no results
                 $data = []; // Ensure $data is an empty array if query returned no results
             }
 
-            $records = Presenter::listTableData($data);
+            // Pass the potentially modified $header to Presenter
+            $records = Presenter::listTableData($data, [], $header);
+
 
         } catch (PDOException $e) {
             setFlashMessage('Error: ' . $e->getMessage());
+            $header = []; // Ensure header is defined for Presenter in error case
             // Ensure variables are set for the view in case of an error
             $data = []; // Set $data to empty array
             $_SESSION['tableData'] = array(); // Clear or set session data appropriately

--- a/app/presenters/presenter.php
+++ b/app/presenters/presenter.php
@@ -20,7 +20,7 @@ HTML;
         return $html;
     }
 
-    public static function listTableData(array $array, $fieldTypes = array())
+    public static function listTableData(array $array, $fieldTypes = array(), $header_row = null)
     {
         //$fieldTypes = convertFieldTypesEditable($fieldTypes);
 
@@ -28,9 +28,21 @@ HTML;
         $html .= '<thead>' . "\n";
 
         // build headings
-        foreach ($array[0] as $head => $value) {
-            $html .= "<th>$head</th>" . "\n";
+        if (!empty($header_row) && is_array($header_row)) {
+            // Use provided header row
+            foreach ($header_row as $head) {
+                $html .= "<th>" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
+            }
+        } elseif (!empty($array) && isset($array[0]) && is_array($array[0])) {
+            // Fallback to inferring from data keys if no header_row or if data is present
+            foreach (array_keys($array[0]) as $head) {
+                $html .= "<th>" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
+            }
+        } else {
+            // No data and no header row, perhaps render an empty header or a message
+            // For now, just an empty thead if no headers can be determined.
         }
+
 
         $html .= '</thead>' . "\n";
 

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -301,6 +301,36 @@ $fields = $fields ?? [];
     <div class="clearfix"></div>
 </div>
 
+<!-- Table Formatting Modal -->
+<div class="modal fade" id="modal-table-format">
+    <div class="modal-dialog modal-lg"> <!-- Using modal-lg for potentially many columns -->
+        <div class="modal-content">
+            <div class="modal-header label-info">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title"><i class="fa fa-paint-brush"></i> Table Display Formatting</h4>
+            </div>
+            <div class="modal-body">
+                <div id="tableFormatMsg" class="alert" style="display:none;"></div>
+                <input type="hidden" id="table_format_query_id" name="table_format_query_id">
+                <p>Define new header titles for your columns. Leave blank to use the default title.</p>
+                <div id="tableFormatFieldsContainer" class="row">
+                    <!-- Dynamic column header input fields will be added here by JavaScript -->
+                    <!-- Example of a single field (will be repeated):
+                    <div class="form-group col-md-4">
+                        <label for="th_original_col_name">Original: original_col_name</label>
+                        <input type="text" class="form-control" id="th_original_col_name" name="header_titles[original_col_name]" placeholder="New Title">
+                    </div>
+                    -->
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
+                <button type="button" class="btn btn-primary" id="btnSaveTableFormatting"><i class="fa fa-save"></i> Save Formatting</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Rename Query Modal -->
 <div class="modal fade" id="modal-rename-query">
     <div class="modal-dialog modal-sm"> <!-- Using modal-sm for a smaller modal -->

--- a/app/views/table.php
+++ b/app/views/table.php
@@ -29,6 +29,11 @@
         <?php if ($can_edit_visually): ?>
             <button type="button" class="btn btn-info" id="btnEditExecutedQuery" style="margin-left: 10px;"><i class="fa fa-pencil"></i> Edit Query in VQB</button>
         <?php endif; ?>
+        <?php if (isset($executed_query_id) && !empty($executed_query_id)): ?>
+            <button type="button" class="btn btn-warning" id="btnShowTableFormatModal" style="margin-left: 10px;" data-query-id="<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>">
+                <i class="fa fa-paint-brush"></i> Format Table
+            </button>
+        <?php endif; ?>
     </div>
     <div class="footer" id="generatedQueryDisplay">
         <?php echo $query; ?>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -37,6 +37,139 @@ $('a.editable').editable({
     }
 });
 
+// --- Table Formatting Modal ---
+$('body').on('click', '#btnShowTableFormatModal', function() {
+    var queryId = $(this).data('query-id');
+    if (!queryId) {
+        $.jGrowl('Error: Query ID is missing. Cannot open formatting modal.', { header: 'Error', theme: 'error' });
+        return;
+    }
+
+    $('#table_format_query_id').val(queryId);
+    var $modal = $('#modal-table-format');
+    var $fieldsContainer = $('#tableFormatFieldsContainer');
+    var $msgContainer = $('#tableFormatMsg');
+    $fieldsContainer.empty().append('<p class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading columns...</p>');
+    $msgContainer.hide().removeClass('alert-success alert-danger alert-info').text('');
+
+    // Fetch current column headers from the displayed table
+    var currentHeaders = [];
+    // Assuming the table is the one within div#tabledata and has a class like .dataTable or .table
+    // More robust selector might be needed if structure varies.
+    // We need the *original* headers, which are in the `<thead>` of the results table.
+    // The Presenter creates <th>OriginalName</th>
+    $('#tabledata table th').each(function() {
+        currentHeaders.push($(this).text());
+    });
+
+    if (currentHeaders.length === 0) {
+        $fieldsContainer.empty().append('<p class="text-danger">Could not find table headers on the page.</p>');
+        $modal.modal('show');
+        return;
+    }
+
+    // Fetch existing formatting for this query_id
+    $.ajax({
+        url: base + '/ajax/getTableFormatting/' + queryId,
+        type: 'GET',
+        dataType: 'json',
+        success: function(response) {
+            $fieldsContainer.empty(); // Clear "Loading..."
+            var existingColumnTitles = {};
+            if (response.status === 'success' && response.table_formatting && response.table_formatting.column_titles) {
+                existingColumnTitles = response.table_formatting.column_titles;
+                 $msgContainer.addClass('alert-info').text('Loaded existing formatting.').show().delay(2000).fadeOut();
+            } else if (response.status !== 'success') {
+                 $msgContainer.addClass('alert-warning').text(response.message || 'Could not load existing formatting.').show();
+            }
+            // If no formatting, existingColumnTitles remains empty, so placeholders will be shown.
+
+            currentHeaders.forEach(function(originalHeader, index) {
+                // The 'name' attribute for inputs needs to be the original header to map correctly on save
+                // We need a way to get the *actual* original DB column name if the displayed header is already a custom one.
+                // For phase 1, the `originalHeader` is what `Presenter` used. If formatting was already applied,
+                // this `originalHeader` *is* the custom title. This is a problem.
+                // The `Presenter` needs to store original names if it's displaying custom ones.
+                //
+                // Workaround for Phase 1: We assume `currentHeaders` are the *original* database column names.
+                // This will be true if formatting has NOT YET been applied by a page reload.
+                // If formatting *has* been applied, this modal will show the *custom* titles as "Original".
+                // This is a limitation of Phase 1 based on current presenter.
+                // For now, let's assume `$(this).text()` from `<th>` is the key to use.
+
+                var inputId = 'th_format_' + index; // Use index for unique ID
+                var newTitle = existingColumnTitles[originalHeader] || ''; // Use originalHeader as key
+
+                var fieldHtml = '<div class="form-group col-md-4">' +
+                                '<label for="' + inputId + '">Original: ' + escapeHtml(originalHeader) + '</label>' +
+                                '<input type="text" class="form-control" id="' + inputId + '" name="header_titles[' + escapeHtml(originalHeader) + ']" value="' + escapeHtml(newTitle) + '" placeholder="New Title (default: ' + escapeHtml(originalHeader) + ')">' +
+                                '</div>';
+                $fieldsContainer.append(fieldHtml);
+            });
+            $modal.modal('show');
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $fieldsContainer.empty();
+            $msgContainer.addClass('alert-danger').text('AJAX Error fetching formatting: ' + textStatus + ' - ' + errorThrown).show();
+            $modal.modal('show'); // Still show modal but with error
+        }
+    });
+});
+
+$('body').on('click', '#btnSaveTableFormatting', function() {
+    var queryId = $('#table_format_query_id').val();
+    var $msgContainer = $('#tableFormatMsg');
+    var $thisButton = $(this);
+
+    if (!queryId) {
+        $msgContainer.removeClass('alert-success alert-info').addClass('alert-danger').text('Error: Query ID is missing.').show();
+        return;
+    }
+
+    var columnTitles = {};
+    $('#tableFormatFieldsContainer .form-control').each(function() {
+        var originalHeaderKey = $(this).attr('name').match(/header_titles\[(.*?)\]/)[1];
+        var newTitle = $(this).val();
+        if ($.trim(newTitle) !== '') { // Only save non-empty titles
+            columnTitles[originalHeaderKey] = $.trim(newTitle);
+        }
+    });
+
+    var tableFormattingJson = JSON.stringify({ column_titles: columnTitles });
+
+    $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
+    $msgContainer.hide().removeClass('alert-success alert-danger alert-info').text('');
+
+    $.ajax({
+        url: base + '/ajax/saveTableFormatting',
+        type: 'POST',
+        data: {
+            query_id: queryId,
+            table_formatting: tableFormattingJson
+        },
+        dataType: 'json',
+        success: function(response) {
+            if (response.status === 'success') {
+                $msgContainer.removeClass('alert-danger alert-info').addClass('alert-success').text(response.message).show();
+                setTimeout(function() {
+                    $('#modal-table-format').modal('hide');
+                    // Optionally, inform user to re-run query to see changes or try to apply dynamically (more complex)
+                    $.jGrowl('Formatting saved. Re-run the query to see changes.', { header: 'Info', theme: 'info', life: 4000 });
+                }, 1500);
+            } else {
+                $msgContainer.removeClass('alert-success alert-info').addClass('alert-danger').text(response.message || 'An unknown error occurred.').show();
+            }
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $msgContainer.removeClass('alert-success alert-info').addClass('alert-danger').text('AJAX Error: ' + textStatus + ' - ' + errorThrown).show();
+        },
+        complete: function() {
+            $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-save');
+        }
+    });
+});
+
+
 $('a.editable').editable();
 
 // for popover

--- a/config.php
+++ b/config.php
@@ -29,6 +29,7 @@ CREATE TABLE saved_queries (
     sql_query TEXT NOT NULL,
     is_visual_query TINYINT(1) NOT NULL DEFAULT 0 COMMENT 'Flag to indicate if the query was created/saved via the visual builder',
     visual_params TEXT NULL COMMENT 'JSON string representing the visual builder parameters',
+    table_formatting TEXT NULL COMMENT 'JSON string representing the table display formatting options',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 */

--- a/routes.php
+++ b/routes.php
@@ -20,4 +20,6 @@ Flight::route('POST /table/[a-zA-Z0-9-_?+]+', 'Table::runquery');
 $lastSegment = Flight::get('lastSegment');
 Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries
+Flight::route('POST /ajax/saveTableFormatting', 'Ajax::saveTableFormatting'); // Route for saving table formatting
+Flight::route('GET /ajax/getTableFormatting/@query_id', 'Ajax::getTableFormatting'); // Route for fetching specific table formatting
 //Flight::route('POST /ajax/@action', 'Ajax::@action');


### PR DESCRIPTION
- Added a new 'table_formatting' JSON column to the 'saved_queries' table to store display preferences.
- Implemented a modal to allow users to change the title text for columns in the query output table.
- Added backend logic to save these formatting preferences (column titles) separately for each saved query.
- Modified the query result display logic to apply saved column titles before rendering the table.
- Integrated frontend components: added a 'Format Table' button on the results page (for saved queries) and JavaScript to manage the formatting modal and AJAX interactions.
- Known limitation for Phase 1: If custom titles are applied and the formatting modal is reopened, the 'original' headers shown in the modal will be the current custom titles, not necessarily the underlying database column names. Reverting to true DB names after multiple edits might require further enhancements.