### PR TITLE
fix: Correct WHERE clause generation in visual query builder

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -312,7 +312,20 @@ class Table
                         if (!$first_where && isset($params['ftype'][$key])) { // ftype links current to previous
                             $query .= ' ' . ($params['ftype'][$key] ?? 'AND') . ' ';
                         }
-                        $query .= $value . $params['fvalue'][$key];
+
+                        // Properly quote the field name ($value is fname)
+                        $quoted_field_name = $value;
+                        if (strpos($value, '.') !== false) {
+                            list($table_part, $column_part) = explode('.', $value, 2);
+                            $quoted_field_name = '`' . str_replace('`', '``', $table_part) . '`.`' . str_replace('`', '``', $column_part) . '`';
+                        } else {
+                            // If no table part, assume it's a column of the primary table or an alias that's already correctly named.
+                            // VQB usually provides qualified names (table.column) for fname.
+                            $quoted_field_name = '`' . str_replace('`', '``', $value) . '`';
+                        }
+
+                        // Append quoted field name, a space, and then the fvalue (which should contain operator + value)
+                        $query .= $quoted_field_name . ' ' . $params['fvalue'][$key];
                         $first_where = false;
                     }
                 }


### PR DESCRIPTION
Ensures that field names in the WHERE clause are properly quoted (e.g., ``table`.`column``) and that a space is correctly inserted between the field name and the user-provided operator/value string (`fvalue`).

This resolves a bug where a field name like `querytest.name` and an `fvalue` of `test1` would incorrectly generate `WHERE querytest.nametest1` instead of `WHERE `querytest`.`name` test1`. The latter is still dependent on the user inputting the operator and quotes correctly in `fvalue` as per the placeholder, but the erroneous direct concatenation is fixed.