### PR TITLE
fix: Prevent duplicate Select2 dropdowns when adding HAVING condition

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -255,6 +255,8 @@ $('#btnAddHavingCondition').click(function () {
 
     // Destroy existing Select2 instance from the template clone if it had one (it shouldn't due to initialSelect2Selector)
     // but good for safety if template structure changes.
+    // Also remove any stray select2 container divs that might have been cloned.
+    $clone.find('.select2-container').remove();
     $hfnameSelect.select2('destroy');
 
     $('#havingConditionsContainer').append($clone);


### PR DESCRIPTION
Ensured that when a new HAVING condition row is cloned and added to the VQB, any pre-existing Select2 container elements (`.select2-container`) within the clone are explicitly removed before the new Select2 instance is initialized. This prevents a visual duplication where both a stale/cloned Select2 widget and the newly initialized functional widget might appear for the same field.

Combined with existing `select2('destroy')` calls, this makes the setup of Select2 for new HAVING clause field dropdowns more robust.