### PR TITLE
fix: Correct Select2 init for HAVING clauses in VQB

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -597,8 +597,18 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
                          if(idx > 0 && visualParamsObj.htype[idx]) {
                              $hClone.find('select[name="htype[]"]').val(visualParamsObj.htype[idx]);
                          }
+                        // Clean the clone before appending
+                        $hClone.find('.select2-container').remove();
+                        var $hfnameSelectInClone = $hClone.find('select.hfname');
+                        if ($hfnameSelectInClone.data('select2')) {
+                            $hfnameSelectInClone.select2('destroy');
+                        }
+                        // Note: Options for $hfnameSelectInClone will be set by the subsequent updateHavingFieldNameOptions call.
+                        // We set the value here; if the option doesn't exist yet, Select2 will pick it up after options are added.
+                        $hfnameSelectInClone.val(name);
+
                         $('#havingConditionsContainer').append($hClone);
-                        $hClone.find('select.hfname').select2(); //Initialize select2 for hfname
+                        // DO NOT initialize Select2 here; updateHavingFieldNameOptions will handle all .hfname in the container.
                     }
                 });
             }
@@ -1035,7 +1045,7 @@ function updateHavingFieldNameOptions() {
         }
     });
 
-    var $hfnameSelects = $('select.hfname');
+    var $hfnameSelects = $('#havingConditionsContainer').find('select.hfname'); // Scoped to active HAVING rows
     var newHtml = '<option value=""></option>'; // Add a blank option for placeholder
 
     // Build HTML for options, handling optgroups if present in the initial set


### PR DESCRIPTION
This commit addresses two issues related to Select2 initialization for HAVING clause field name dropdowns (`.hfname`):

1.  Scoped `updateHavingFieldNameOptions` selector: Changed the selector within `updateHavingFieldNameOptions` from global `$('select.hfname')` to `$('#havingConditionsContainer').find('select.hfname')`. This prevents the function from inadvertently targeting and initializing Select2 on the select element within the hidden `#fieldCloneHaving` template, thus keeping the template pristine.

2.  Removed premature Select2 init when populating saved HAVING clauses: In `openVisualQueryBuilderModal`, when iterating through saved HAVING conditions (`visualParamsObj.hfname`), the explicit Select2 initialization on the cloned row's `.hfname` select was removed. The subsequent single call to `updateHavingFieldNameOptions` (which now uses the correct scoped selector) is now solely responsible for initializing Select2 on all HAVING field name dropdowns, including newly populated saved ones and those added by the user via the button.

These changes ensure that Select2 is initialized cleanly and only once on the relevant select elements after their options are correctly populated, resolving issues like the 'query function not defined' error and the 'two pulldowns' visual bug when adding/editing HAVING conditions.