### PR TITLE
feat: Implement frontend for shareable query reports (Phase 2)

### DIFF
--- a/app/views/dashboard.php
+++ b/app/views/dashboard.php
@@ -22,6 +22,9 @@
                                 <button type="button" class="btn btn-danger btn-sm btn-delete-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 5px;">
                                     <i class="fa fa-trash-o"></i> Delete
                                 </button>
+                                <button type="button" class="btn btn-info btn-sm btn-share-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 5px;">
+                                    <i class="fa fa-share-alt"></i> Share
+                                </button>
                             </div>
                         </li>
                     <?php endforeach; ?>

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -301,6 +301,35 @@ $fields = $fields ?? [];
     <div class="clearfix"></div>
 </div>
 
+<!-- Share Query Modal -->
+<div class="modal fade" id="modal-share-query">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header label-info">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title"><i class="fa fa-share-alt"></i> Share Query Report</h4>
+            </div>
+            <div class="modal-body">
+                <p>Anyone with the following link can view the results of the query: <strong id="shareQueryName"></strong></p>
+                <p><small>This link provides read-only access to the report data. It does not allow modification of the query or access to other parts of the application.</small></p>
+                <div class="input-group">
+                    <input type="text" class="form-control" id="shareableLinkInput" readonly>
+                    <span class="input-group-btn">
+                        <button class="btn btn-default" type="button" id="btnCopyShareLink" title="Copy to Clipboard">
+                            <i class="fa fa-clipboard"></i> Copy
+                        </button>
+                    </span>
+                </div>
+                <div id="shareLinkMsg" class="alert alert-success" style="display:none; margin-top: 10px;">Link copied to clipboard!</div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
+                <!-- Future: <button type="button" class="btn btn-warning" id="btnRegenerateShareLink"><i class="fa fa-refresh"></i> Regenerate Link</button> -->
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Table Formatting Modal -->
 <div class="modal fade" id="modal-table-format">
     <div class="modal-dialog modal-lg"> <!-- Using modal-lg for potentially many columns -->

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -139,6 +139,86 @@ $('body').on('click', '#btnShowTableFormatModal', function() {
     });
 });
 
+// --- Share Query Modal Functionality ---
+$('body').on('click', '.btn-share-query', function() {
+    var queryId = $(this).data('query-id');
+    var queryName = $(this).data('query-name'); // Assuming query name is also available on the button
+
+    var $modal = $('#modal-share-query');
+    var $linkInput = $('#shareableLinkInput');
+    var $queryNameDisplay = $('#shareQueryName');
+    var $copyBtn = $('#btnCopyShareLink');
+    var $shareLinkMsg = $('#shareLinkMsg');
+
+    $queryNameDisplay.text(queryName || 'Selected Query'); // Display query name
+    $linkInput.val('Loading link...'); // Placeholder while fetching
+    $shareLinkMsg.hide();
+    $copyBtn.prop('disabled', true);
+
+    // Show modal first, then populate
+    $modal.modal('show');
+
+    $.ajax({
+        url: base + '/ajax/getShareToken/' + queryId,
+        type: 'GET',
+        dataType: 'json',
+        success: function(response) {
+            if (response.status === 'success' && response.token) {
+                var shareUrl = base + '/share/' + response.token;
+                // Ensure 'base' doesn't end with a slash if '/share/' already starts with one.
+                // Or ensure 'base' ends with a slash and '/share/' doesn't start with one.
+                // Current 'base' is like 'http://localhost/querycloud', so need to ensure no double slashes.
+                // A robust way to build URL:
+                var appBaseUrl = (base.endsWith('/') ? base.substring(0, base.length -1) : base);
+                shareUrl = appBaseUrl + '/share/' + response.token;
+
+                $linkInput.val(shareUrl);
+                $copyBtn.prop('disabled', false);
+            } else {
+                $linkInput.val('Could not generate share link.');
+                $.jGrowl(response.message || 'Error fetching share link.', { header: 'Error', theme: 'error' });
+            }
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+            $linkInput.val('Error fetching link.');
+            $.jGrowl('AJAX Error: ' + textStatus + ' - ' + errorThrown, { header: 'AJAX Error', theme: 'error' });
+        }
+    });
+});
+
+$('body').on('click', '#btnCopyShareLink', function() {
+    var $linkInput = $('#shareableLinkInput');
+    var $shareLinkMsg = $('#shareLinkMsg');
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText($linkInput.val()).then(function() {
+            $shareLinkMsg.text('Link copied to clipboard!').fadeIn().delay(2000).fadeOut();
+        }).catch(function(err) {
+            // Fallback for older browsers or if permission denied
+            try {
+                $linkInput[0].select();
+                document.execCommand('copy');
+                $shareLinkMsg.text('Link copied to clipboard! (fallback method)').fadeIn().delay(2000).fadeOut();
+            } catch (e) {
+                $shareLinkMsg.text('Failed to copy. Please copy manually.').removeClass('alert-success').addClass('alert-danger').fadeIn().delay(3000).fadeOut(function(){
+                    $(this).removeClass('alert-danger').addClass('alert-success'); // Reset class
+                });
+            }
+        });
+    } else { // Fallback for very old browsers
+        try {
+            $linkInput[0].select();
+            document.execCommand('copy');
+            $shareLinkMsg.text('Link copied to clipboard! (fallback method)').fadeIn().delay(2000).fadeOut();
+        } catch (e) {
+             $shareLinkMsg.text('Failed to copy. Please copy manually.').removeClass('alert-success').addClass('alert-danger').fadeIn().delay(3000).fadeOut(function(){
+                $(this).removeClass('alert-danger').addClass('alert-success'); // Reset class
+            });
+        }
+    }
+});
+
+
 $('body').on('click', '#btnSaveTableFormatting', function() {
     var queryId = $('#table_format_query_id').val();
     var $msgContainer = $('#tableFormatMsg');


### PR DESCRIPTION
This commit completes the frontend integration for the shareable query reports feature.

- Dashboard: Added a 'Share' button to each saved query item in `app/views/dashboard.php`, including `data-query-id` and `data-query-name` attributes.
- Share Modal: Created the `modal-share-query` in `app/views/includes/modals.php` with a read-only input for the shareable URL, a 'Copy to Clipboard' button, and descriptive text.
- JavaScript Logic: Implemented JavaScript in `assets/js/custom.js` for:
    - Handling clicks on the 'Share' button.
    - Making an AJAX GET request to `/ajax/getShareToken/{query_id}` to retrieve or generate the share token.
    - Constructing the full shareable URL and populating it into the modal.
    - Showing the share modal.
    - Implementing 'Copy to Clipboard' functionality for the shareable link, with fallbacks.

This phase builds upon the backend logic (token generation, public report view) established in Phase 1.