### PR TITLE
refactor: Add site_url config and robust handling for share URLs

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -409,7 +409,19 @@ class Ajax
             }
 
             $config = Flight::get('config');
-            $site_url = rtrim($config['site_url'], '/');
+            $site_url_from_config = ''; // Default to empty string
+
+            if (is_array($config) && isset($config['site_url']) && is_string($config['site_url']) && !empty(trim($config['site_url']))) {
+                $site_url_from_config = $config['site_url'];
+            } else {
+                error_log("WARNING: config['site_url'] is not properly set in config.php. Share URLs may be incomplete.");
+                // If site_url is critical and must be absolute, you might choose to return an error here:
+                // $response['message'] = "Configuration error: Site URL not set. Cannot generate share links.";
+                // echo json_encode($response);
+                // return;
+            }
+
+            $site_url = rtrim($site_url_from_config, '/');
 
             if (!empty($saved_query->share_token)) {
                 $response['status'] = 'success';
@@ -536,7 +548,14 @@ class Ajax
                 $response['token'] = $saved_query->share_token;
 
                 $config = Flight::get('config');
-                $site_url = rtrim($config['site_url'], '/');
+                $site_url_from_config = ''; // Default to empty string
+                if (is_array($config) && isset($config['site_url']) && is_string($config['site_url']) && !empty(trim($config['site_url']))) {
+                    $site_url_from_config = $config['site_url'];
+                } else {
+                    error_log("WARNING: config['site_url'] is not properly set in config.php. Share URLs may be incomplete in updateShareSettings response.");
+                }
+                $site_url = rtrim($site_url_from_config, '/');
+
                 if ($saved_query->share_token) {
                     $response['share_url'] = $site_url . '/share/' . $saved_query->share_token;
                 } else {

--- a/app/controllers/login.php
+++ b/app/controllers/login.php
@@ -57,25 +57,44 @@ class Login
             $redirect_url = $_GET['redirect_to'] ?? null;
             if ($redirect_url) {
                 $config = Flight::get('config');
-                $site_url = rtrim($config['site_url'], '/');
+                $site_url_from_config = '';
+                if (is_array($config) && isset($config['site_url']) && is_string($config['site_url']) && !empty(trim($config['site_url']))) {
+                    $site_url_from_config = $config['site_url'];
+                } else {
+                    error_log("WARNING: config['site_url'] is not properly set for LoginController redirect validation. Redirect might be less secure or default.");
+                }
+                $site_url = rtrim($site_url_from_config, '/');
+                $app_base_path = rtrim(Flight::get('base'), '/'); // Path like /querycloud or empty if root
+
                 $share_path_segment = '/share/';
 
-                // Check if the redirect_url starts with the site_url + share_path_segment
-                // Or if it's a relative URL starting with the share_path_segment (more robust for same-origin redirects)
-                $is_valid_absolute_share_redirect = strpos($redirect_url, $site_url . $share_path_segment) === 0;
+                // Normalize redirect_url if it's relative to the app base path for comparison with site_url
+                $absolute_redirect_url = $redirect_url;
+                if (strpos($redirect_url, 'http') !== 0) { // If it's not already absolute
+                    if (strpos($redirect_url, '/') === 0) { // Starts with / e.g. /share/token or /appbase/share/token
+                        if (!empty($app_base_path) && strpos($redirect_url, $app_base_path) === 0) {
+                            // Already contains base path, e.g. /querycloud/share/token. Can be used as is for local redirect.
+                            // For comparison with site_url, we might need to prepend scheme and host if site_url is full.
+                            // However, Flight::redirect can handle paths relative to app root.
+                        } else if (!empty($app_base_path)) {
+                             // Relative to app root but doesn't include base, e.g. /share/token when base is /querycloud
+                             // This case is tricky. Flight::redirect($redirect_url) might work if app is at domain root.
+                             // If app is in subdir, $app_base_path . $redirect_url would be needed for some redirect methods.
+                             // For now, let's assume Flight::redirect handles paths starting with '/' from actual domain root.
+                        }
+                    } else { // Truly relative e.g. share/token - less likely from urlencode
+                        $absolute_redirect_url = $app_base_path . '/' . $redirect_url;
+                    }
+                }
+
+                // Check if the (potentially now absolute) redirect_url starts with the site_url + share_path_segment
+                // Or if the original redirect_url (if relative) starts with the share_path_segment
+                $is_valid_absolute_share_redirect = !empty($site_url) && strpos($absolute_redirect_url, $site_url . $share_path_segment) === 0;
                 $is_valid_relative_share_redirect = strpos($redirect_url, $share_path_segment) === 0 &&
                                                     (strpos($redirect_url, '//') === false && strpos($redirect_url, 'http:') !== 0 && strpos($redirect_url, 'https:') !== 0);
 
-
-                if ($is_valid_absolute_share_redirect) {
-                    // It's an absolute URL matching our site and share path
-                    Flight::redirect($redirect_url);
-                    return;
-                } elseif ($is_valid_relative_share_redirect) {
-                    // It's a relative path like /share/TOKEN. Prepend site_url if base Flight::redirect needs it,
-                    // or let Flight::redirect handle relative paths correctly.
-                    // Flight::redirect usually handles relative paths from app root.
-                    Flight::redirect($redirect_url);
+                if ($is_valid_absolute_share_redirect || $is_valid_relative_share_redirect) {
+                    Flight::redirect($redirect_url); // Flight::redirect should handle both absolute and relative-to-base paths
                     return;
                 }
                 // If not a valid share redirect, fall through to default.

--- a/app/controllers/share.php
+++ b/app/controllers/share.php
@@ -31,7 +31,17 @@ class Share
             if (!isset($_SESSION['logged']) || !$_SESSION['logged']) {
                 // User is not logged in, redirect to login page with a redirect_to parameter
                 $config = Flight::get('config');
-                $site_url = rtrim($config['site_url'], '/');
+                $site_url_from_config = '';
+                if (is_array($config) && isset($config['site_url']) && is_string($config['site_url']) && !empty(trim($config['site_url']))) {
+                    $site_url_from_config = $config['site_url'];
+                } else {
+                    error_log("CRITICAL: config['site_url'] is not properly set for ShareController redirect. Login redirect may fail or be relative.");
+                    // Fallback: Attempt relative redirect if site_url is missing. This might not work if 'base' is also not set well.
+                    $base_path = rtrim(Flight::get('base'), '/'); // Flight::get('base') is often just the subdirectory
+                    Flight::redirect($base_path . '/login?redirect_to=' . urlencode($base_path . '/share/' . $token));
+                    return;
+                }
+                $site_url = rtrim($site_url_from_config, '/');
                 $current_share_url = $site_url . '/share/' . $token;
                 Flight::redirect($site_url . '/login?redirect_to=' . urlencode($current_share_url));
                 return; // Stop further execution
@@ -105,7 +115,14 @@ class Share
         }
 
         $config = Flight::get('config');
-        $site_url_for_view = rtrim($config['site_url'], '/');
+        $site_url_for_view = ''; // Default to empty string
+        if (is_array($config) && isset($config['site_url']) && is_string($config['site_url']) && !empty(trim($config['site_url']))) {
+            $site_url_for_view = rtrim($config['site_url'], '/');
+        } else {
+            error_log("WARNING: config['site_url'] is not properly set for ShareController view rendering. Asset/export links will use relative paths based on Flight::get('base').");
+            // Fallback to Flight::get('base') for asset paths if site_url is missing.
+            $site_url_for_view = rtrim(Flight::get('base'), '/');
+        }
 
 
         Flight::render(


### PR DESCRIPTION
Introduced a `$config['site_url']` parameter in `config.php` to define the application's full canonical base URL.

Updates include:
- `config.php`: Added `site_url`.
- `AjaxController` (`getShareToken`, `updateShareSettings`): Modified to construct and return full `share_url`s using `site_url`. Added robust checks for `site_url` presence and type, defaulting to relative paths and logging a warning if not properly set.
- `ShareController` (`viewReport`): Uses `site_url` for constructing `redirect_to` URLs for login. Passes `site_url` (as `base_site_url`) to the `share_report.php` view. If `site_url` is not configured, it falls back to `Flight::get('base')` for `base_site_url` and logs a warning.
- `LoginController` (`loginuser`): Validates `redirect_to` parameter against `site_url` or relative `/share/` paths, with safeguards for missing `site_url`.
- `share_report.php` view: Updated to use `base_site_url` for all asset and export links, ensuring they are built from the canonical site URL or a correct base path.

This ensures more robust generation and handling of full shareable URLs and related links, preventing fatal errors if `site_url` is misconfigured.