### PR TITLE
fix: Correct unterminated comment in AjaxController

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -463,6 +463,7 @@ class Ajax
                     $response['message'] = 'Failed to generate a unique share token after multiple attempts.';
                     error_log("Failed to generate unique share token for query_id: $query_id after $max_attempts attempts.");
                 }
+                */ // Correctly terminate the comment block here
             }
         } catch (PDOException $e) {
             error_log("Database error in getShareToken for query_id $query_id: " . $e->getMessage());


### PR DESCRIPTION
Resolved a PHP fatal syntax error in `app/controllers/ajax.php` caused by an unterminated block comment within the `getShareToken` method (around the previously commented-out token auto-generation logic).

This error prevented AJAX endpoints in this file from executing correctly, leading to HTML error output instead of JSON responses, and causing `parsererror` on the client-side (e.g., when opening the share modal or when VQB tried to fetch field options via `getselectfields`).

The fix ensures the comment block is properly terminated, allowing the PHP file to be parsed correctly and AJAX endpoints to function as intended.