### PR TITLE
Fix: Ensure login redirect_to parameter is correctly persisted and pr…

### DIFF
--- a/app/controllers/login.php
+++ b/app/controllers/login.php
@@ -53,9 +53,21 @@ class Login
         if ($username_ok && $password_ok) {
             $_SESSION['logged'] = true;
 
-            // Handle redirect_to parameter
-            $redirect_url_param = $_GET['redirect_to'] ?? null;
+            // Handle redirect_to parameter - prioritize POST, then GET
+            $redirect_url_param = null;
+            if (!empty($_POST['redirect_to'])) {
+                $redirect_url_param = $_POST['redirect_to'];
+            } elseif (!empty($_GET['redirect_to'])) {
+                // Fallback to GET, though POST should be the primary source with the hidden field
+                $redirect_url_param = $_GET['redirect_to'];
+                 error_log("INFO: redirect_to parameter obtained from GET on POST request. Source: " . ($_SERVER['REQUEST_URI'] ?? 'N/A'));
+            }
+
             if ($redirect_url_param) {
+                // Add a log to show where the redirect_url_param came from
+                $source = !empty($_POST['redirect_to']) ? 'POST' : (!empty($_GET['redirect_to']) ? 'GET' : 'NONE');
+                error_log("DEBUG: redirect_url_param is '$redirect_url_param', sourced from $source");
+
                 $app_base_path = rtrim(Flight::get('base'), '/'); // e.g., /querycloud or empty if root
                 $expected_share_path_prefix = $app_base_path . '/share/';
 

--- a/app/views/login.php
+++ b/app/views/login.php
@@ -76,6 +76,7 @@
         <h2 class="form-signin-heading">Please sign in</h2>
         <input type="text" name="username" class="form-control" placeholder="Username" required autofocus>
         <input type="password" name="password" class="form-control" placeholder="Password" required>
+        <input type="hidden" name="redirect_to" value="<?php echo htmlspecialchars($_GET['redirect_to'] ?? ''); ?>">
         <button class="btn btn-lg btn-primary btn-block" type="submit"><i class="fa fa-sign-in"></i> Sign in</button>
     </form>
 </div>


### PR DESCRIPTION
…ocessed

This commit addresses the core login redirect issue by ensuring the `redirect_to` URL parameter is persisted across the login form submission and handled correctly by the controller.

Key changes:

1.  **Persist `redirect_to` in Login Form (`app/views/login.php`):**
    - Added a hidden input field to the login form to capture the `redirect_to` value from the initial GET request.
    - Used `htmlspecialchars` to safely embed this value in the HTML.

2.  **Process `redirect_to` from POST (`app/controllers/login.php`):**
    - Modified the `loginuser` method to primarily read the `redirect_to` parameter from `$_POST` (submitted by the hidden field).
    - Retained a fallback to `$_GET` for robustness, though `$_POST` is now the expected source.
    - Added logging to trace the source of the `redirect_to` parameter.

3.  **Host Validation (`app/controllers/login.php`):**
    - Verified that the existing scheme-agnostic, www-agnostic, and port-agnostic (for host part) host validation logic remains effective with the new parameter sourcing.

4.  **Bootstrap JS Error (`app/views/login.php`):**
    - Confirmed that the fix for the 'Bootstrap requires jQuery' error (loading jQuery before Bootstrap JS) is in place.

This set of changes should now correctly redirect users after login when a valid `redirect_to` parameter is provided, including scenarios with differing HTTP/HTTPS schemes between the login page and the redirect target (on the same domain).