### PR TITLE
Feat: Enhance Share Modal with 'Generate URL' button and improved UX

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -575,4 +575,116 @@ class Ajax
 
         echo json_encode($response);
     }
+
+    public static function generateOrUpdateShareToken()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
+
+        $query_id = $_POST['query_id'] ?? null;
+        $require_login_input = $_POST['require_login'] ?? null; // Expected 'true' or 'false' as string, or boolean
+
+        if (empty($query_id) || !is_numeric($query_id)) {
+            $response['message'] = 'Invalid Query ID provided.';
+            echo json_encode($response);
+            return;
+        }
+
+        if ($require_login_input === null) {
+            $response['message'] = 'Require login status not provided.';
+            echo json_encode($response);
+            return;
+        }
+
+        // Handle boolean true/false or string "true"/"false"
+        if (is_string($require_login_input)) {
+            if (strtolower($require_login_input) === 'true') {
+                $require_login = true;
+            } elseif (strtolower($require_login_input) === 'false') {
+                $require_login = false;
+            } else {
+                $response['message'] = 'Invalid string value for require_login. Must be "true" or "false".';
+                echo json_encode($response);
+                return;
+            }
+        } elseif (is_bool($require_login_input)) {
+            $require_login = $require_login_input;
+        } else {
+            $response['message'] = 'Invalid type for require_login. Must be boolean or string "true"/"false".';
+            echo json_encode($response);
+            return;
+        }
+
+        try {
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+            if (!$saved_query) {
+                $response['message'] = 'Query not found.';
+                echo json_encode($response);
+                return;
+            }
+
+            // Always ensure a token exists if we are calling this endpoint.
+            // If it doesn't exist, generate one. If it exists, reuse it.
+            // Regeneration (creating a new token to invalidate old one) could be a future feature.
+            if (empty($saved_query->share_token)) {
+                $token = null;
+                $max_attempts = 5;
+                for ($i = 0; $i < $max_attempts; $i++) {
+                    $potential_token = bin2hex(random_bytes(32));
+                    if (ORM::for_table('saved_queries')->where('share_token', $potential_token)->count() == 0) {
+                        $token = $potential_token;
+                        break;
+                    }
+                }
+                if ($token) {
+                    $saved_query->share_token = $token;
+                    $response['message_detail'] = 'New share token generated.';
+                } else {
+                    $response['message'] = 'Failed to generate a unique share token.';
+                    error_log("Failed to generate unique share token during generateOrUpdateShareToken for query_id: $query_id");
+                    echo json_encode($response);
+                    return;
+                }
+            } else {
+                 $response['message_detail'] = 'Existing share token retained.';
+            }
+
+            $saved_query->share_requires_login = $require_login ? 1 : 0;
+
+            if ($saved_query->save()) {
+                $response['status'] = 'success';
+                $response['message'] = 'Share URL processed successfully. ' . ($response['message_detail'] ?? '');
+                $response['requires_login'] = (bool)$saved_query->share_requires_login;
+                $response['token'] = $saved_query->share_token;
+
+                $config = Flight::get('config');
+                $site_url_from_config = rtrim($config['site_url'] ?? '', '/');
+
+                if (empty($site_url_from_config)) {
+                     error_log("WARNING: config['site_url'] is not properly set. Share URLs may be incomplete in generateOrUpdateShareToken response.");
+                }
+
+                if ($saved_query->share_token) {
+                    $response['share_url'] = $site_url_from_config . '/share/' . $saved_query->share_token;
+                } else {
+                    // This case should not be reached if token generation logic above is correct
+                    $response['share_url'] = null;
+                    $response['message'] = 'Error: Token was expected but is missing after save.';
+                    $response['status'] = 'error';
+                }
+            } else {
+                $response['message'] = 'Failed to save share settings to the database.';
+            }
+        } catch (PDOException $e) {
+            error_log("Database error in generateOrUpdateShareToken for query_id $query_id: " . $e->getMessage());
+            $response['message'] = 'Database error: ' . $e->getMessage();
+        } catch (Exception $e) {
+            error_log("General error in generateOrUpdateShareToken for query_id $query_id: " . $e->getMessage());
+            $response['message'] = 'An unexpected error occurred: ' . $e->getMessage();
+        }
+
+        unset($response['message_detail']); // Don't send this internal detail to client
+        echo json_encode($response);
+    }
 }

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -312,15 +312,24 @@ $fields = $fields ?? [];
             <div class="modal-body">
                 <p>Anyone with the following link can view the results of the query: <strong id="shareQueryName"></strong></p>
                 <p><small>This link provides read-only access to the report data. It does not allow modification of the query or access to other parts of the application.</small></p>
-                <div class="input-group">
-                    <input type="text" class="form-control" id="shareableLinkInput" readonly>
-                    <span class="input-group-btn">
-                        <button class="btn btn-default" type="button" id="btnCopyShareLink" title="Copy to Clipboard">
-                            <i class="fa fa-clipboard"></i> Copy
-                        </button>
-                    </span>
+
+                <div id="shareLinkGenerationArea" style="margin-bottom: 10px;">
+                    <!-- This div will be shown/hidden by JS. It might contain the button or the link+copy -->
                 </div>
-                <div id="shareLinkMsg" class="alert alert-success" style="display:none; margin-top: 10px;">Link copied to clipboard!</div>
+                <div id="shareLinkDisplayArea" style="display:none;">
+                    <div class="input-group">
+                        <input type="text" class="form-control" id="shareableLinkInput" readonly>
+                        <span class="input-group-btn">
+                            <button class="btn btn-default" type="button" id="btnCopyShareLink" title="Copy to Clipboard">
+                                <i class="fa fa-clipboard"></i> Copy
+                            </button>
+                        </span>
+                    </div>
+                    <div id="shareLinkCopiedMsg" class="alert alert-success" style="display:none; margin-top: 10px;">Link copied to clipboard!</div>
+                </div>
+                <button type="button" class="btn btn-primary" id="btnGenerateShareUrl" style="margin-top: 5px; margin-bottom:10px;"><i class="fa fa-link"></i> Generate Share URL</button>
+                <div id="shareGenerationStatusMsg" style="margin-top: 5px; font-style: italic;"></div>
+
 
                 <hr style="margin-top: 15px; margin-bottom: 15px;">
 

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -148,62 +148,86 @@ $('body').on('click', '.btn-share-query', function() {
     var $linkInput = $('#shareableLinkInput');
     var $queryNameDisplay = $('#shareQueryName');
     var $copyBtn = $('#btnCopyShareLink');
-    var $shareLinkMsg = $('#shareLinkMsg');
-    var $requireLoginCheckbox = $('#shareRequireLoginCheckbox');
-    var $shareSettingsMsg = $('#shareSettingsMsg');
+    var $queryNameDisplay = $('#shareQueryName');
+    var $modal = $('#modal-share-query');
 
-    $modal.data('current-query-id', queryId); // Store queryId on the modal for the checkbox handler
+    $modal.data('current-query-id', queryId);
     $queryNameDisplay.text(queryName || 'Selected Query');
-    $linkInput.val('Loading link...');
-    $shareLinkMsg.hide();
-    $shareSettingsMsg.hide().removeClass('text-success text-danger').text('');
-    $copyBtn.prop('disabled', true);
-    $requireLoginCheckbox.prop('checked', false).prop('disabled', true); // Disable until loaded
 
+    fetchShareSettings(queryId); // New function to handle display logic
     $modal.modal('show');
+});
+
+function fetchShareSettings(queryId) {
+    var $modal = $('#modal-share-query');
+    var $linkInput = $('#shareableLinkInput');
+    var $copyBtn = $('#btnCopyShareLink');
+    var $requireLoginCheckbox = $('#shareRequireLoginCheckbox');
+    var $shareGenerationStatusMsg = $('#shareGenerationStatusMsg');
+    var $shareLinkDisplayArea = $('#shareLinkDisplayArea');
+    var $btnGenerate = $('#btnGenerateShareUrl');
+
+    // Initial state while loading
+    $linkInput.val('');
+    $shareLinkDisplayArea.hide();
+    $shareGenerationStatusMsg.text('Loading settings...').show();
+    $copyBtn.prop('disabled', true);
+    $requireLoginCheckbox.prop('checked', false).prop('disabled', true);
+    $btnGenerate.prop('disabled', true);
 
     $.ajax({
-        url: base + '/ajax/getShareToken/' + queryId,
+        url: base + '/ajax/getShareToken/' + queryId, // Existing endpoint
         type: 'GET',
         dataType: 'json',
         success: function(response) {
             if (response.status === 'success') {
                 if (response.share_url) {
                     $linkInput.val(response.share_url);
+                    $shareLinkDisplayArea.show();
                     $copyBtn.prop('disabled', false);
+                    $shareGenerationStatusMsg.text('Share URL is active.').delay(3000).fadeOut();
+                    $btnGenerate.text('Regenerate URL / Update Settings');
                 } else {
-                    // No token/URL yet.
-                    $linkInput.val('No public link generated yet. Check "Require Login" to generate or if already checked, save settings.');
-                    $copyBtn.prop('disabled', true); // Disable copy if no URL
+                    $linkInput.val('');
+                    $shareLinkDisplayArea.hide();
+                    $shareGenerationStatusMsg.text("No public link generated yet. Click 'Generate Share URL' to create one.").show();
+                    $btnGenerate.text('Generate Share URL');
                 }
                 $requireLoginCheckbox.prop('checked', response.requires_login || false);
             } else {
-                $linkInput.val('Could not retrieve share settings.');
-                $.jGrowl(response.message || 'Error fetching share link.', { header: 'Error', theme: 'error' });
+                $shareGenerationStatusMsg.text(response.message || 'Could not retrieve share settings.').addClass('text-danger').show();
+                $btnGenerate.text('Generate Share URL');
             }
         },
         error: function(jqXHR, textStatus, errorThrown) {
-            $linkInput.val('Error fetching link.');
-            $.jGrowl('AJAX Error: ' + textStatus + ' - ' + errorThrown, { header: 'AJAX Error', theme: 'error' });
+            $shareGenerationStatusMsg.text('Error fetching link: ' + textStatus).addClass('text-danger').show();
+            $btnGenerate.text('Generate Share URL');
         },
         complete: function() {
-            $requireLoginCheckbox.prop('disabled', false); // Enable checkbox after loading
+            $requireLoginCheckbox.prop('disabled', false);
+            $btnGenerate.prop('disabled', false);
         }
     });
-});
+}
 
-// Handler for the "Require Login" checkbox change
-$('body').on('change', '#shareRequireLoginCheckbox', function() {
+function generateOrUpdateShareLink() {
     var queryId = $('#modal-share-query').data('current-query-id');
-    var requireLogin = $(this).is(':checked');
-    var $shareSettingsMsg = $('#shareSettingsMsg');
-    var $linkInput = $('#shareableLinkInput');
-    var $copyBtn = $('#btnCopyShareLink');
+    if (!queryId) {
+        $.jGrowl('Error: Query ID not found in modal.', { header: 'Error', theme: 'error' });
+        return;
+    }
 
-    $shareSettingsMsg.hide().removeClass('text-success text-danger').text('Saving...');
+    var requireLogin = $('#shareRequireLoginCheckbox').is(':checked');
+    var $shareGenerationStatusMsg = $('#shareGenerationStatusMsg');
+    var $btnGenerate = $('#btnGenerateShareUrl');
+    var $requireLoginCheckbox = $('#shareRequireLoginCheckbox');
+
+    $shareGenerationStatusMsg.text('Processing...').removeClass('text-danger text-success').show();
+    $btnGenerate.prop('disabled', true);
+    $requireLoginCheckbox.prop('disabled', true);
 
     $.ajax({
-        url: base + '/ajax/updateShareSettings',
+        url: base + '/ajax/generate_share_token', // NEW Endpoint
         type: 'POST',
         data: {
             query_id: queryId,
@@ -212,46 +236,52 @@ $('body').on('change', '#shareRequireLoginCheckbox', function() {
         dataType: 'json',
         success: function(response) {
             if (response.status === 'success') {
-                $shareSettingsMsg.addClass('text-success').text(response.message || 'Settings saved!').fadeIn().delay(2000).fadeOut();
-                // Update checkbox state based on server response for consistency, though it should match user's click
-                $requireLoginCheckbox.prop('checked', response.requires_login || false);
-
-                if (response.share_url) {
-                    $linkInput.val(response.share_url);
-                    $copyBtn.prop('disabled', false);
-                } else if (!response.requires_login) {
-                    // If requireLogin is false and no token/URL (e.g., token was cleared or never generated for public)
-                    $linkInput.val('No public link generated (login not required and no active link).');
-                    $copyBtn.prop('disabled', true);
-                } else if (response.requires_login && !response.share_url) {
-                    // This case implies require_login is true, but backend failed to return/generate a URL/token.
-                    // Ajax::updateShareSettings should always generate a token if require_login is true and no token exists.
-                    $linkInput.val('Error: Link should be active but was not provided.');
-                    $copyBtn.prop('disabled', true);
-                } else { // Fallback, e.g. if requires_login true but no token
-                     $linkInput.val('Link status unclear. Refresh modal.');
-                     $copyBtn.prop('disabled', true);
-                }
+                // Refresh the modal display with the new/updated settings
+                fetchShareSettings(queryId);
+                // fetchShareSettings will handle enabling controls and updating messages.
+                // We can show a temporary success message here if desired, then fetchShareSettings will overwrite it.
+                $shareGenerationStatusMsg.text(response.message || 'URL processed successfully!').addClass('text-success').show().delay(2000).fadeOut(function() {
+                    // After fading out, fetchShareSettings's message might take over or it might be empty if link is active
+                    if ($('#shareableLinkInput').val()) {
+                        $(this).text('Share URL is active.').show().delay(2000).fadeOut();
+                    } else {
+                         $(this).text("No public link generated yet. Click 'Generate Share URL' to create one.").show();
+                    }
+                });
             } else {
-                $shareSettingsMsg.addClass('text-danger').text(response.message || 'Failed to save settings.').fadeIn();
-                // Revert checkbox state on failure? Or leave as is and let user retry?
-                // For now, leave as is. User can try again.
+                $shareGenerationStatusMsg.text(response.message || 'Failed to process share URL.').addClass('text-danger').show();
+                $btnGenerate.prop('disabled', false); // Re-enable on failure
+                $requireLoginCheckbox.prop('disabled', false);
             }
         },
         error: function(jqXHR, textStatus, errorThrown) {
-            $shareSettingsMsg.addClass('text-danger').text('AJAX Error: Could not save settings. ' + textStatus).fadeIn();
+            $shareGenerationStatusMsg.text('AJAX Error: ' + textStatus + ' - ' + errorThrown).addClass('text-danger').show();
+            $btnGenerate.prop('disabled', false); // Re-enable on AJAX error
+            $requireLoginCheckbox.prop('disabled', false);
         }
+        // 'complete' is handled by fetchShareSettings enabling controls if called, or by error callbacks above
     });
+}
+
+// Event listener for the new "Generate Share URL" button
+$('body').on('click', '#btnGenerateShareUrl', function() {
+    generateOrUpdateShareLink();
+});
+
+// Modified handler for the "Require Login" checkbox change
+$('body').on('change', '#shareRequireLoginCheckbox', function() {
+    // Now, changing the checkbox will also trigger the generation/update logic
+    generateOrUpdateShareLink();
 });
 
 
 $('body').on('click', '#btnCopyShareLink', function() {
     var $linkInput = $('#shareableLinkInput');
-    var $shareLinkMsg = $('#shareLinkMsg');
+    var $shareLinkCopiedMsg = $('#shareLinkCopiedMsg'); // Use the new ID
 
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText($linkInput.val()).then(function() {
-            $shareLinkMsg.text('Link copied to clipboard!').fadeIn().delay(2000).fadeOut();
+            $shareLinkCopiedMsg.text('Link copied to clipboard!').fadeIn().delay(2000).fadeOut();
         }).catch(function(err) {
             // Fallback for older browsers or if permission denied
             try {

--- a/routes.php
+++ b/routes.php
@@ -22,8 +22,10 @@ Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries
 Flight::route('POST /ajax/saveTableFormatting', 'Ajax::saveTableFormatting'); // Route for saving table formatting
 Flight::route('GET /ajax/getTableFormatting/@query_id', 'Ajax::getTableFormatting'); // Route for fetching specific table formatting
-Flight::route('GET /ajax/getShareToken/@query_id', 'Ajax::getShareToken'); // Route for getting/generating a share token
-Flight::route('POST /ajax/updateShareSettings', 'Ajax::updateShareSettings'); // Route for updating share settings (e.g. require_login)
+Flight::route('GET /ajax/getShareToken/@query_id', 'Ajax::getShareToken');
+Flight::route('POST /ajax/updateShareSettings', 'Ajax::updateShareSettings');
+Flight::route('POST /ajax/generate_share_token', 'Ajax::generateOrUpdateShareToken'); // New route for generating/updating share token
+
 //Flight::route('POST /ajax/@action', 'Ajax::@action');
 
 // Public share route


### PR DESCRIPTION
This commit revamps the Share Query modal to provide a more user-friendly way to generate and manage shareable report links.

Key changes include:

1.  **Share Modal HTML (`app/views/includes/modals.php`):**
    - Replaced the previous dynamic text about link generation with an explicit "Generate Share URL" button (`#btnGenerateShareUrl`).
    - Added a dedicated area (`#shareLinkDisplayArea`) to show the generated link and copy button, initially hidden.
    - Added a status message div (`#shareGenerationStatusMsg`) for user feedback.

2.  **JavaScript Logic (`assets/js/custom.js`):**
    - Refactored the modal opening logic (`.btn-share-query` click).
    - Introduced `fetchShareSettings(queryId)` to load and display the current share status (URL, login requirement) when the modal opens.
    - Implemented `generateOrUpdateShareLink()` function, which is called by:
        - Clicking the new `#btnGenerateShareUrl` button.
        - Changing the state of the `#shareRequireLoginCheckbox`.
    - This function makes an AJAX POST request to a new backend endpoint (`/ajax/generate_share_token`) to create/update the share token and its `require_login` status.
    - On success, `fetchShareSettings()` is called to refresh the modal display, ensuring UI consistency.

3.  **Backend Endpoint (`app/controllers/ajax.php` & `routes.php`):**
    - Added a new public static method `generateOrUpdateShareToken()` to the `Ajax` class.
    - This method handles:
        - Receiving `query_id` and `require_login` status.
        - Generating a new unique `share_token` if one doesn't exist for the query (existing tokens are currently reused). - Updating the `share_requires_login` flag. - Saving changes to the `saved_queries` table. - Returning the full `share_url` and current settings.
    - Added a new route `POST /ajax/generate_share_token` in `routes.php` to map to this new controller method.

The "Require Login" checkbox state is now saved automatically when changed or when the generate button is clicked, as both actions trigger the backend update.