### PR TITLE
feat: Add ETL configuration and fix table formatting

### DIFF
--- a/app/controllers/Destinations.php
+++ b/app/controllers/Destinations.php
@@ -1,0 +1,66 @@
+<?php
+
+class Destinations
+{
+    private static $icon = 'fa fa-database';
+
+    public static function index()
+    {
+        self::checkLogin();
+
+        $destinations = ORM::for_table('destination_databases')->order_by_asc('connection_name')->find_many();
+
+        Flight::render(
+            'destinations',
+            array(
+                'title' => 'Manage Destinations',
+                'icon' => self::$icon,
+                'destinations' => $destinations
+            )
+        );
+    }
+
+    public static function add()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $destination = ORM::for_table('destination_databases')->create();
+            $destination->connection_name = $_POST['connection_name'];
+            $destination->db_host = $_POST['db_host'];
+            $destination->db_port = $_POST['db_port'];
+            $destination->db_name = $_POST['db_name'];
+            $destination->db_user = $_POST['db_user'];
+            $destination->db_password = $_POST['db_password']; // Security Note: Storing plain text password
+            $destination->save();
+
+            setFlashMessage('Destination added successfully!');
+        }
+
+        Flight::redirect('/destinations');
+    }
+
+    public static function delete()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
+            $destination = ORM::for_table('destination_databases')->find_one($_POST['id']);
+            if ($destination) {
+                $destination->delete();
+                setFlashMessage('Destination deleted successfully!');
+            } else {
+                setFlashMessage('Error: Destination not found.', 'error');
+            }
+        }
+
+        Flight::redirect('/destinations');
+    }
+
+    private static function checkLogin()
+    {
+        if (!isset($_SESSION['logged'])) {
+            Flight::redirect('./login');
+        }
+    }
+}

--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -1,0 +1,78 @@
+<?php
+
+class ETL
+{
+    private static $icon = 'fa fa-cogs';
+
+    public static function index($query_id)
+    {
+        self::checkLogin();
+
+        // Fetch the saved query
+        $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+        if (!$saved_query) {
+            setFlashMessage('Error: Saved query not found.', 'error');
+            Flight::redirect('/dashboard');
+            return;
+        }
+
+        // Fetch all available destinations
+        $destinations = ORM::for_table('destination_databases')->order_by_asc('connection_name')->find_many();
+
+        // Decode existing ETL config to pass to the view
+        $etl_config = array();
+        if ($saved_query->etl_config) {
+            $etl_config = json_decode($saved_query->etl_config, true);
+        }
+
+        Flight::render(
+            'etl',
+            array(
+                'title' => 'ETL Configuration for ' . $saved_query->query_name,
+                'icon' => self::$icon,
+                'saved_query' => $saved_query,
+                'destinations' => $destinations,
+                'etl_config' => $etl_config
+            )
+        );
+    }
+
+    public static function save()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $query_id = $_POST['query_id'];
+            $destination_id = $_POST['destination_id'];
+            $destination_table = $_POST['destination_table'];
+
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+            if ($saved_query) {
+                $etl_config = array(
+                    'destination_db_id' => $destination_id,
+                    'destination_table_name' => $destination_table
+                );
+
+                $saved_query->etl_config = json_encode($etl_config);
+                $saved_query->save();
+
+                setFlashMessage('ETL configuration saved successfully!');
+            } else {
+                setFlashMessage('Error: Saved query not found.', 'error');
+            }
+
+            Flight::redirect('/etl/' . $query_id);
+        } else {
+            Flight::redirect('/dashboard');
+        }
+    }
+
+    private static function checkLogin()
+    {
+        if (!isset($_SESSION['logged'])) {
+            Flight::redirect('./login');
+        }
+    }
+}

--- a/app/views/destinations.php
+++ b/app/views/destinations.php
@@ -1,0 +1,82 @@
+<?php require_once 'includes/header.php'; ?>
+
+<div class="page-content inset">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="panel panel-primary">
+                <div class="panel-heading">Add New Destination</div>
+                <div class="panel-body">
+                    <form action="<?php echo Flight::get('base'); ?>/destinations/add" method="post" role="form">
+                        <div class="form-group">
+                            <label for="connection_name">Connection Name</label>
+                            <input type="text" class="form-control" id="connection_name" name="connection_name" placeholder="e.g., Production DWH" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_host">Host</label>
+                            <input type="text" class="form-control" id="db_host" name="db_host" placeholder="e.g., 127.0.0.1" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_port">Port</label>
+                            <input type="number" class="form-control" id="db_port" name="db_port" placeholder="e.g., 3306" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_name">Database Name</label>
+                            <input type="text" class="form-control" id="db_name" name="db_name" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_user">Username</label>
+                            <input type="text" class="form-control" id="db_user" name="db_user" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_password">Password</label>
+                            <input type="password" class="form-control" id="db_password" name="db_password" required>
+                        </div>
+                        <button type="submit" class="btn btn-success"><i class="fa fa-plus"></i> Add Destination</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="panel panel-default">
+                <div class="panel-heading">Existing Destinations</div>
+                <div class="panel-body">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Connection Name</th>
+                                <th>Host</th>
+                                <th>Database</th>
+                                <th>User</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (isset($destinations) && count($destinations) > 0): ?>
+                                <?php foreach ($destinations as $dest): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($dest->connection_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_host, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_user, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <form action="<?php echo Flight::get('base'); ?>/destinations/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this destination?');">
+                                                <input type="hidden" name="id" value="<?php echo $dest->id; ?>">
+                                                <button type="submit" class="btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php else: ?>
+                                <tr>
+                                    <td colspan="5" class="text-center">No destinations configured yet.</td>
+                                </tr>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once 'includes/footer.php'; ?>

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -1,0 +1,63 @@
+<?php require_once 'includes/header.php'; ?>
+
+<div class="page-content inset">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">ETL Configuration for Query: "<?php echo htmlspecialchars($saved_query->query_name, ENT_QUOTES, 'UTF-8'); ?>"</h3>
+                </div>
+                <div class="panel-body">
+
+                    <h4>Saved SQL Query:</h4>
+                    <div class="well well-sm">
+                        <pre><code><?php echo htmlspecialchars($saved_query->sql_query, ENT_QUOTES, 'UTF-8'); ?></code></pre>
+                    </div>
+
+                    <hr>
+
+                    <h4>Destination Setup:</h4>
+                    <form class="form-horizontal" action="<?php echo Flight::get('base'); ?>/etl/save" method="post" role="form">
+                        <input type="hidden" name="query_id" value="<?php echo $saved_query->id; ?>">
+
+                        <div class="form-group">
+                            <label for="destination_id" class="col-sm-3 control-label">Destination Connection</label>
+                            <div class="col-sm-6">
+                                <select class="form-control" id="destination_id" name="destination_id" required>
+                                    <option value="">-- Select a Destination --</option>
+                                    <?php if (isset($destinations)): ?>
+                                        <?php foreach ($destinations as $dest): ?>
+                                            <option value="<?php echo $dest->id; ?>" <?php echo (isset($etl_config['destination_db_id']) && $etl_config['destination_db_id'] == $dest->id) ? 'selected' : ''; ?>>
+                                                <?php echo htmlspecialchars($dest->connection_name, ENT_QUOTES, 'UTF-8'); ?> (<?php echo htmlspecialchars($dest->db_host, ENT_QUOTES, 'UTF-8'); ?>)
+                                            </option>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="destination_table" class="col-sm-3 control-label">Destination Table Name</label>
+                            <div class="col-sm-6">
+                                <input type="text" class="form-control" id="destination_table" name="destination_table"
+                                       placeholder="e.g., daily_sales_summary"
+                                       value="<?php echo isset($etl_config['destination_table_name']) ? htmlspecialchars($etl_config['destination_table_name'], ENT_QUOTES, 'UTF-8') : ''; ?>" required>
+                                <p class="help-block">The table where the query results will be inserted. The table must exist.</p>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-sm-6">
+                                <button type="submit" class="btn btn-primary"><i class="fa fa-save"></i> Save Configuration</button>
+                                <a href="<?php echo Flight::get('base'); ?>/dashboard" class="btn btn-default">Cancel</a>
+                            </div>
+                        </div>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once 'includes/footer.php'; ?>

--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -54,6 +54,9 @@
         <br/>
 
         <ul class="sidebar-nav">
+            <li><a href="<?php echo Flight::get('base'); ?>/dashboard"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="<?php echo Flight::get('base'); ?>/destinations"><i class="fa fa-rocket"></i> Manage Destinations</a></li>
+            <li class="nav-divider"></li>
             <?php echo Flight::get('tables'); ?>
             <!-- Saved Queries link removed, queries are now shown on dashboard -->
         </ul>

--- a/app/views/table.php
+++ b/app/views/table.php
@@ -33,6 +33,9 @@
             <button type="button" class="btn btn-warning" id="btnShowTableFormatModal" style="margin-left: 10px;" data-query-id="<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>">
                 <i class="fa fa-paint-brush"></i> Format Table
             </button>
+            <a href="<?php echo Flight::get('base'); ?>/etl/<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-info" style="margin-left: 10px;">
+                <i class="fa fa-cogs"></i> ETL
+            </a>
         <?php endif; ?>
     </div>
     <div class="footer" id="generatedQueryDisplay">

--- a/routes.php
+++ b/routes.php
@@ -12,6 +12,16 @@ Flight::route('POST /login', 'Login::loginuser');
 Flight::route('GET /login/logout', 'Login::logout');
 
 Flight::route('GET /dashboard', 'Dashboard::index');
+
+// Destination Management
+Flight::route('GET /destinations', 'Destinations::index');
+Flight::route('POST /destinations/add', 'Destinations::add');
+Flight::route('POST /destinations/delete', 'Destinations::delete');
+
+// ETL Configuration
+Flight::route('GET /etl/@query_id:[0-9]+', 'ETL::index');
+Flight::route('POST /etl/save', 'ETL::save');
+
 Flight::route('GET /export/csv', 'Export::csv');
 Flight::route('GET /export/excel', 'Export::excel');
 Flight::route('GET /table/[a-zA-Z0-9-_?+]+', 'Table::index');


### PR DESCRIPTION
This commit introduces a new feature for configuring ETL (Extract, Transform, Load) processes for saved queries. It also includes a fix for the 'Format Table' modal.

ETL Configuration Feature:
- Adds a new `destination_databases` table to store connection credentials for target databases.
- Adds an `etl_config` column to the `saved_queries` table to store the destination database and table for a query.
- Creates a new 'Manage Destinations' page (`/destinations`) for CRUD operations on destination connections.
- Creates a new 'ETL Configuration' page (`/etl/{query_id}`) where a user can select a destination and specify a table name for a saved query.
- Adds an 'ETL' button to the query results page to link to the configuration page.

Fix for Table Formatting Modal:
- The 'Format Table' modal on the query result page now correctly remembers and displays previously saved column header titles.
- The `presenter` is updated to include a `data-original-name` attribute on table headers (`<th>`), which holds the original database column name.
- The corresponding JavaScript is updated to use this attribute to correctly look up and populate the modal with saved custom titles.