### PR TITLE
Fix: Prevent DataTables warning on empty destinations table

### DIFF
--- a/app/views/destinations.php
+++ b/app/views/destinations.php
@@ -66,10 +66,6 @@
                                         </td>
                                     </tr>
                                 <?php endforeach; ?>
-                            <?php else: ?>
-                                <tr>
-                                    <td colspan="5" class="text-center">No destinations configured yet.</td>
-                                </tr>
                             <?php endif; ?>
                         </tbody>
                     </table>


### PR DESCRIPTION
This commit fixes a DataTables warning that occurred on the `/destinations` page when the list of destinations was empty.

The error `Requested unknown parameter '1' for row 0` was caused by the table body containing a single row with a `<td>` that had a `colspan="5"`. The DataTables library expects each row to have the same number of cells as there are headers and does not correctly handle `colspan` in this initialization scenario.

The fix is to remove the `else` condition that generated this row. Now, if there are no destinations, the `<tbody>` will be empty, allowing the DataTables library to correctly initialize and display its default "No data available in table" message.