### PR TITLE
feat: Implement ETL execution and complete ETL feature

### DIFF
--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -69,6 +69,81 @@ class ETL
         }
     }
 
+    public static function run()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            Flight::redirect('/dashboard');
+            return;
+        }
+
+        $query_id = $_POST['query_id'];
+        $redirect_url = Flight::get('base') . '/etl/' . $query_id;
+
+        try {
+            // 1. Fetch Query and Destination Details from the form POST
+            // This ensures we run with the config currently on the screen, even if not saved.
+            $destination_id = $_POST['destination_id'];
+            $destination_table = $_POST['destination_table'];
+
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+            if (!$saved_query) {
+                throw new Exception("Saved query not found.");
+            }
+
+            $destination_db_details = ORM::for_table('destination_databases')->find_one($destination_id);
+            if (!$destination_db_details) {
+                throw new Exception("Destination database configuration not found.");
+            }
+
+            // 2. Establish Destination Connection
+            $dsn = "mysql:host={$destination_db_details->db_host};port={$destination_db_details->db_port};dbname={$destination_db_details->db_name};charset=utf8";
+            $dest_pdo = new PDO($dsn, $destination_db_details->db_user, $destination_db_details->db_password);
+            $dest_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            // 3. Fetch Source Data
+            $source_pdo = Flight::get('db');
+            $source_stmt = $source_pdo->prepare($saved_query->sql_query);
+            $source_stmt->execute();
+            $source_data = $source_stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            if (empty($source_data)) {
+                setFlashMessage('Source query returned no data. Nothing to insert.', 'info');
+                Flight::redirect($redirect_url);
+                return;
+            }
+
+            // 4. Prepare and Insert Data into Destination
+            $columns = array_keys($source_data[0]);
+            $column_list = '`' . implode('`, `', $columns) . '`';
+            $placeholders = rtrim(str_repeat('?,', count($columns)), ',');
+
+            $insert_sql = "INSERT INTO `{$destination_table}` ({$column_list}) VALUES ({$placeholders})";
+
+            $dest_pdo->beginTransaction();
+
+            $insert_stmt = $dest_pdo->prepare($insert_sql);
+
+            foreach ($source_data as $row) {
+                $insert_stmt->execute(array_values($row));
+            }
+
+            $dest_pdo->commit();
+
+            $rowCount = count($source_data);
+            setFlashMessage("Successfully inserted {$rowCount} rows into `{$destination_table}`.");
+
+        } catch (Exception $e) {
+            if (isset($dest_pdo) && $dest_pdo->inTransaction()) {
+                $dest_pdo->rollBack();
+            }
+            setFlashMessage("ETL Error: " . $e->getMessage(), 'error');
+        }
+
+        Flight::redirect($redirect_url);
+    }
+
     private static function checkLogin()
     {
         if (!isset($_SESSION['logged'])) {

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -48,7 +48,10 @@
 
                         <div class="form-group">
                             <div class="col-sm-offset-3 col-sm-6">
-                                <button type="submit" class="btn btn-primary"><i class="fa fa-save"></i> Save Configuration</button>
+                                <button type="submit" class="btn btn-primary" formaction="<?php echo Flight::get('base'); ?>/etl/save"><i class="fa fa-save"></i> Save Configuration</button>
+                                <?php if (!empty($etl_config['destination_db_id']) && !empty($etl_config['destination_table_name'])): ?>
+                                    <button type="submit" class="btn btn-success" formaction="<?php echo Flight::get('base'); ?>/etl/run"><i class="fa fa-play"></i> Run ETL Now</button>
+                                <?php endif; ?>
                                 <a href="<?php echo Flight::get('base'); ?>/dashboard" class="btn btn-default">Cancel</a>
                             </div>
                         </div>

--- a/routes.php
+++ b/routes.php
@@ -21,6 +21,7 @@ Flight::route('POST /destinations/delete', 'Destinations::delete');
 // ETL Configuration
 Flight::route('GET /etl/@query_id:[0-9]+', 'ETL::index');
 Flight::route('POST /etl/save', 'ETL::save');
+Flight::route('POST /etl/run', 'ETL::run');
 
 Flight::route('GET /export/csv', 'Export::csv');
 Flight::route('GET /export/excel', 'Export::excel');


### PR DESCRIPTION
This commit adds the execution logic to the ETL feature, completing the functionality. It also includes the initial setup for ETL configuration and a fix for the table formatting modal from previous steps.

ETL Execution:
- A `run()` method is added to the `ETL` controller to handle the ETL process.
- The `run()` method connects to the source and destination databases, executes the saved query, and inserts the results into the specified destination table.
- The process is wrapped in a database transaction on the destination for data integrity.
- Error handling is included to catch exceptions during the process and provide feedback to the user via flash messages.
- A "Run ETL" button is added to the ETL configuration page, which triggers this process.

Previous Feature Additions included in this commit:
- Initial setup for ETL configuration, including a new `destinations` table, new controllers, views, and routes.
- A fix for the 'Format Table' modal, ensuring it correctly remembers and displays saved column header customizations by using a `data-original-name` attribute on table headers.