### PR TITLE
feat: Convert sidebar table list to a dropdown menu

### DIFF
--- a/app/controllers/Destinations.php
+++ b/app/controllers/Destinations.php
@@ -1,0 +1,66 @@
+<?php
+
+class Destinations
+{
+    private static $icon = 'fa fa-database';
+
+    public static function index()
+    {
+        self::checkLogin();
+
+        $destinations = ORM::for_table('destination_databases')->order_by_asc('connection_name')->find_many();
+
+        Flight::render(
+            'destinations',
+            array(
+                'title' => 'Manage Destinations',
+                'icon' => self::$icon,
+                'destinations' => $destinations
+            )
+        );
+    }
+
+    public static function add()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $destination = ORM::for_table('destination_databases')->create();
+            $destination->connection_name = $_POST['connection_name'];
+            $destination->db_host = $_POST['db_host'];
+            $destination->db_port = $_POST['db_port'];
+            $destination->db_name = $_POST['db_name'];
+            $destination->db_user = $_POST['db_user'];
+            $destination->db_password = $_POST['db_password']; // Security Note: Storing plain text password
+            $destination->save();
+
+            setFlashMessage('Destination added successfully!');
+        }
+
+        Flight::redirect('/destinations');
+    }
+
+    public static function delete()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
+            $destination = ORM::for_table('destination_databases')->find_one($_POST['id']);
+            if ($destination) {
+                $destination->delete();
+                setFlashMessage('Destination deleted successfully!');
+            } else {
+                setFlashMessage('Error: Destination not found.', 'error');
+            }
+        }
+
+        Flight::redirect('/destinations');
+    }
+
+    private static function checkLogin()
+    {
+        if (!isset($_SESSION['logged'])) {
+            Flight::redirect('./login');
+        }
+    }
+}

--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -1,0 +1,153 @@
+<?php
+
+class ETL
+{
+    private static $icon = 'fa fa-cogs';
+
+    public static function index($query_id)
+    {
+        self::checkLogin();
+
+        // Fetch the saved query
+        $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+        if (!$saved_query) {
+            setFlashMessage('Error: Saved query not found.', 'error');
+            Flight::redirect('/dashboard');
+            return;
+        }
+
+        // Fetch all available destinations
+        $destinations = ORM::for_table('destination_databases')->order_by_asc('connection_name')->find_many();
+
+        // Decode existing ETL config to pass to the view
+        $etl_config = array();
+        if ($saved_query->etl_config) {
+            $etl_config = json_decode($saved_query->etl_config, true);
+        }
+
+        Flight::render(
+            'etl',
+            array(
+                'title' => 'ETL Configuration for ' . $saved_query->query_name,
+                'icon' => self::$icon,
+                'saved_query' => $saved_query,
+                'destinations' => $destinations,
+                'etl_config' => $etl_config
+            )
+        );
+    }
+
+    public static function save()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $query_id = $_POST['query_id'];
+            $destination_id = $_POST['destination_id'];
+            $destination_table = $_POST['destination_table'];
+
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+
+            if ($saved_query) {
+                $etl_config = array(
+                    'destination_db_id' => $destination_id,
+                    'destination_table_name' => $destination_table
+                );
+
+                $saved_query->etl_config = json_encode($etl_config);
+                $saved_query->save();
+
+                setFlashMessage('ETL configuration saved successfully!');
+            } else {
+                setFlashMessage('Error: Saved query not found.', 'error');
+            }
+
+            Flight::redirect('/etl/' . $query_id);
+        } else {
+            Flight::redirect('/dashboard');
+        }
+    }
+
+    public static function run()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            Flight::redirect('/dashboard');
+            return;
+        }
+
+        $query_id = $_POST['query_id'];
+        $redirect_url = Flight::get('base') . '/etl/' . $query_id;
+
+        try {
+            // 1. Fetch Query and Destination Details from the form POST
+            // This ensures we run with the config currently on the screen, even if not saved.
+            $destination_id = $_POST['destination_id'];
+            $destination_table = $_POST['destination_table'];
+
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+            if (!$saved_query) {
+                throw new Exception("Saved query not found.");
+            }
+
+            $destination_db_details = ORM::for_table('destination_databases')->find_one($destination_id);
+            if (!$destination_db_details) {
+                throw new Exception("Destination database configuration not found.");
+            }
+
+            // 2. Establish Destination Connection
+            $dsn = "mysql:host={$destination_db_details->db_host};port={$destination_db_details->db_port};dbname={$destination_db_details->db_name};charset=utf8";
+            $dest_pdo = new PDO($dsn, $destination_db_details->db_user, $destination_db_details->db_password);
+            $dest_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            // 3. Fetch Source Data
+            $source_pdo = Flight::get('db');
+            $source_stmt = $source_pdo->prepare($saved_query->sql_query);
+            $source_stmt->execute();
+            $source_data = $source_stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            if (empty($source_data)) {
+                setFlashMessage('Source query returned no data. Nothing to insert.', 'info');
+                Flight::redirect($redirect_url);
+                return;
+            }
+
+            // 4. Prepare and Insert Data into Destination
+            $columns = array_keys($source_data[0]);
+            $column_list = '`' . implode('`, `', $columns) . '`';
+            $placeholders = rtrim(str_repeat('?,', count($columns)), ',');
+
+            $insert_sql = "INSERT INTO `{$destination_table}` ({$column_list}) VALUES ({$placeholders})";
+
+            $dest_pdo->beginTransaction();
+
+            $insert_stmt = $dest_pdo->prepare($insert_sql);
+
+            foreach ($source_data as $row) {
+                $insert_stmt->execute(array_values($row));
+            }
+
+            $dest_pdo->commit();
+
+            $rowCount = count($source_data);
+            setFlashMessage("Successfully inserted {$rowCount} rows into `{$destination_table}`.");
+
+        } catch (Exception $e) {
+            if (isset($dest_pdo) && $dest_pdo->inTransaction()) {
+                $dest_pdo->rollBack();
+            }
+            setFlashMessage("ETL Error: " . $e->getMessage(), 'error');
+        }
+
+        Flight::redirect($redirect_url);
+    }
+
+    private static function checkLogin()
+    {
+        if (!isset($_SESSION['logged'])) {
+            Flight::redirect('./login');
+        }
+    }
+}

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -457,36 +457,17 @@ class Table
 // Extract column names from DESCRIBE result
 //print_r($data);
             if (!empty($data) && isset($data[0])) {
-                $header = array_keys($data[0]);
+                $original_header = array_keys($data[0]); // <-- Keep the original headers
+                $display_header = $original_header; // By default, display header is the original
 
                 // --- Apply Table Formatting ---
-                // Check if we are running a saved query that might have formatting
-                $current_query_id_for_formatting = null;
-                if ($running_saved_query_name) { // If a saved query by name was run
-                    // Try to get its ID. This part might be slightly redundant if executed_query_id is already reliably set later
-                    // but good to have a direct path if possible.
-                    $temp_saved_query = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
-                    if ($temp_saved_query) {
-                        $current_query_id_for_formatting = $temp_saved_query->id;
-                    }
-                }
-                // If visual_query_params are present, and they contain an 'executed_query_id', that's another source
-                // This is primarily for when "Edit Query" is used from a saved query.
-                // For direct "Run Query" from dashboard, running_saved_query_name is the primary source.
-                // The logic to get executed_query_id for view_data later is more comprehensive.
-                // For applying formatting, we need the ID *before* Presenter::listTableData.
-
-                // Let's refine how we get the query_id for formatting, using the same logic as for view_data population
                 $query_id_for_formatting_lookup = null;
-                if (isset($_POST['executed_query_id']) && !empty($_POST['executed_query_id'])) { // If explicitly passed (e.g. during an edit flow)
+                if (isset($_POST['executed_query_id']) && !empty($_POST['executed_query_id'])) {
                      $query_id_for_formatting_lookup = $_POST['executed_query_id'];
-                } else if ($running_saved_query_name) { // If a saved query was run by name
+                } else if ($running_saved_query_name) {
                     $sq_details = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
                     if ($sq_details) $query_id_for_formatting_lookup = $sq_details->id;
                 }
-                // $_POST['query_id'] might also be relevant if a query is saved and run immediately.
-                // However, the current flow for "Save" doesn't immediately run and apply formatting.
-                // Formatting is applied when a *saved* query is run.
 
                 if ($query_id_for_formatting_lookup) {
                     $query_with_formatting = ORM::for_table('saved_queries')->find_one($query_id_for_formatting_lookup);
@@ -494,12 +475,11 @@ class Table
                         try {
                             $formatting_rules = json_decode($query_with_formatting->table_formatting, true);
                             if (json_last_error() === JSON_ERROR_NONE && isset($formatting_rules['column_titles'])) {
-                                $new_header = [];
-                                foreach ($header as $original_col_name) {
-                                    // Use the new title if defined and not empty, otherwise use original
-                                    $new_header[] = (!empty($formatting_rules['column_titles'][$original_col_name])) ? $formatting_rules['column_titles'][$original_col_name] : $original_col_name;
+                                $new_display_header = [];
+                                foreach ($original_header as $original_col_name) {
+                                    $new_display_header[] = (!empty($formatting_rules['column_titles'][$original_col_name])) ? $formatting_rules['column_titles'][$original_col_name] : $original_col_name;
                                 }
-                                $header = $new_header; // Replace original header with formatted one
+                                $display_header = $new_display_header; // Set the display header to the formatted one
                             }
                         } catch (Exception $e) {
                             error_log("Error decoding table formatting JSON: " . $e->getMessage());
@@ -508,20 +488,21 @@ class Table
                 }
                 // --- End Apply Table Formatting ---
 
-                $_SESSION['tableData'] = array($header);  // Header row as array, now potentially with custom titles
+                $_SESSION['tableData'] = array($display_header);  // Use display_header for session/export data
 
                 foreach ($data as $row) {
-                    $_SESSION['tableData'][] = array_values($row);  // Data rows as arrays
+                    $_SESSION['tableData'][] = array_values($row);
                 }
             } else {
-                // Handle empty result set for session data
-                $header = []; // No header if no data
-                $_SESSION['tableData'] = array(); // Store empty data or a specific format for no results
-                $data = []; // Ensure $data is an empty array if query returned no results
+                // Handle empty result set
+                $original_header = [];
+                $display_header = [];
+                $_SESSION['tableData'] = array();
+                $data = [];
             }
 
-            // Pass the potentially modified $header to Presenter
-            $records = Presenter::listTableData($data, [], $header);
+            // Pass both original and display headers to Presenter
+            $records = Presenter::listTableData($data, [], $display_header, $original_header);
 
 
         } catch (PDOException $e) {

--- a/app/presenters/presenter.php
+++ b/app/presenters/presenter.php
@@ -20,29 +20,48 @@ HTML;
         return $html;
     }
 
-    public static function listTableData(array $array, $fieldTypes = array(), $header_row = null)
+    public static function listTablesAsOptions(array $array)
     {
-        //$fieldTypes = convertFieldTypesEditable($fieldTypes);
+        $html = '';
+        $base = Flight::get('base');
+        $current_table = Flight::get('lastSegment');
 
+        foreach ($array as $arrayitem) {
+            $selected = ($current_table == $arrayitem) ? 'selected' : '';
+            $url = "$base/table/$arrayitem";
+            $html .= "<option value=\"{$url}\" {$selected}>" . htmlspecialchars($arrayitem, ENT_QUOTES, 'UTF-8') . "</option>\n";
+        }
+
+        return $html;
+    }
+
+    public static function listTableData(array $array, $fieldTypes = array(), $display_header = null, $original_header = null)
+    {
         $html = '<table class="table table-striped table-bordered table-hover">' . "\n";
         $html .= '<thead>' . "\n";
 
-        // build headings
-        if (!empty($header_row) && is_array($header_row)) {
-            // Use provided header row
-            foreach ($header_row as $head) {
-                $html .= "<th>" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
-            }
-        } elseif (!empty($array) && isset($array[0]) && is_array($array[0])) {
-            // Fallback to inferring from data keys if no header_row or if data is present
-            foreach (array_keys($array[0]) as $head) {
-                $html .= "<th>" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
-            }
-        } else {
-            // No data and no header row, perhaps render an empty header or a message
-            // For now, just an empty thead if no headers can be determined.
+        // If original_header is not provided, fallback to display_header for keys
+        if ($original_header === null) {
+            $original_header = $display_header;
         }
 
+        // build headings
+        if (!empty($display_header) && is_array($display_header)) {
+            foreach ($display_header as $index => $head) {
+                // Use the original header name for the data attribute
+                $original_name_attr = '';
+                if (isset($original_header[$index])) {
+                    $original_name_attr = 'data-original-name="' . htmlspecialchars($original_header[$index], ENT_QUOTES, 'UTF-8') . '"';
+                }
+                $html .= "<th " . $original_name_attr . ">" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
+            }
+        } elseif (!empty($array) && isset($array[0]) && is_array($array[0])) {
+            // Fallback to inferring from data keys if no header info is provided
+            foreach (array_keys($array[0]) as $head) {
+                // In this fallback, original and display names are the same
+                $html .= "<th data-original-name=\"" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "\">" . htmlspecialchars($head, ENT_QUOTES, 'UTF-8') . "</th>" . "\n";
+            }
+        }
 
         $html .= '</thead>' . "\n";
 

--- a/app/views/dashboard.php
+++ b/app/views/dashboard.php
@@ -13,6 +13,9 @@
                                 <button type="button" class="btn btn-warning btn-sm btn-rename-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 10px;">
                                     <i class="fa fa-i-cursor"></i> Rename
                                 </button>
+                                <a href="<?php echo Flight::get('base'); ?>/etl/<?php echo htmlspecialchars($query['id']); ?>" class="btn btn-success btn-sm" style="margin-left: 5px;">
+                                    <i class="fa fa-cogs"></i> ETL
+                                </a>
                                 <button type="button" class="btn btn-info btn-sm btn-edit-saved-query" data-query-id="<?php echo htmlspecialchars($query['id']); ?>" data-query-name="<?php echo htmlspecialchars($query['query_name']); ?>" style="margin-left: 5px;">
                                     <i class="fa fa-pencil"></i> Edit SQL/Visual
                                 </button>

--- a/app/views/destinations.php
+++ b/app/views/destinations.php
@@ -1,0 +1,78 @@
+<?php require_once 'includes/header.php'; ?>
+
+<div class="page-content inset">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="panel panel-primary">
+                <div class="panel-heading">Add New Destination</div>
+                <div class="panel-body">
+                    <form action="<?php echo Flight::get('base'); ?>/destinations/add" method="post" role="form">
+                        <div class="form-group">
+                            <label for="connection_name">Connection Name</label>
+                            <input type="text" class="form-control" id="connection_name" name="connection_name" placeholder="e.g., Production DWH" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_host">Host</label>
+                            <input type="text" class="form-control" id="db_host" name="db_host" placeholder="e.g., 127.0.0.1" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_port">Port</label>
+                            <input type="number" class="form-control" id="db_port" name="db_port" placeholder="e.g., 3306" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_name">Database Name</label>
+                            <input type="text" class="form-control" id="db_name" name="db_name" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_user">Username</label>
+                            <input type="text" class="form-control" id="db_user" name="db_user" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_password">Password</label>
+                            <input type="password" class="form-control" id="db_password" name="db_password" required>
+                        </div>
+                        <button type="submit" class="btn btn-success"><i class="fa fa-plus"></i> Add Destination</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="panel panel-default">
+                <div class="panel-heading">Existing Destinations</div>
+                <div class="panel-body">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Connection Name</th>
+                                <th>Host</th>
+                                <th>Database</th>
+                                <th>User</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (isset($destinations) && count($destinations) > 0): ?>
+                                <?php foreach ($destinations as $dest): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($dest->connection_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_host, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_user, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <form action="<?php echo Flight::get('base'); ?>/destinations/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this destination?');">
+                                                <input type="hidden" name="id" value="<?php echo $dest->id; ?>">
+                                                <button type="submit" class="btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once 'includes/footer.php'; ?>

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -1,0 +1,66 @@
+<?php require_once 'includes/header.php'; ?>
+
+<div class="page-content inset">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">ETL Configuration for Query: "<?php echo htmlspecialchars($saved_query->query_name, ENT_QUOTES, 'UTF-8'); ?>"</h3>
+                </div>
+                <div class="panel-body">
+
+                    <h4>Saved SQL Query:</h4>
+                    <div class="well well-sm">
+                        <pre><code><?php echo htmlspecialchars($saved_query->sql_query, ENT_QUOTES, 'UTF-8'); ?></code></pre>
+                    </div>
+
+                    <hr>
+
+                    <h4>Destination Setup:</h4>
+                    <form class="form-horizontal" action="<?php echo Flight::get('base'); ?>/etl/save" method="post" role="form">
+                        <input type="hidden" name="query_id" value="<?php echo $saved_query->id; ?>">
+
+                        <div class="form-group">
+                            <label for="destination_id" class="col-sm-3 control-label">Destination Connection</label>
+                            <div class="col-sm-6">
+                                <select class="form-control" id="destination_id" name="destination_id" required>
+                                    <option value="">-- Select a Destination --</option>
+                                    <?php if (isset($destinations)): ?>
+                                        <?php foreach ($destinations as $dest): ?>
+                                            <option value="<?php echo $dest->id; ?>" <?php echo (isset($etl_config['destination_db_id']) && $etl_config['destination_db_id'] == $dest->id) ? 'selected' : ''; ?>>
+                                                <?php echo htmlspecialchars($dest->connection_name, ENT_QUOTES, 'UTF-8'); ?> (<?php echo htmlspecialchars($dest->db_host, ENT_QUOTES, 'UTF-8'); ?>)
+                                            </option>
+                                        <?php endforeach; ?>
+                                    <?php endif; ?>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="destination_table" class="col-sm-3 control-label">Destination Table Name</label>
+                            <div class="col-sm-6">
+                                <input type="text" class="form-control" id="destination_table" name="destination_table"
+                                       placeholder="e.g., daily_sales_summary"
+                                       value="<?php echo isset($etl_config['destination_table_name']) ? htmlspecialchars($etl_config['destination_table_name'], ENT_QUOTES, 'UTF-8') : ''; ?>" required>
+                                <p class="help-block">The table where the query results will be inserted. The table must exist.</p>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <div class="col-sm-offset-3 col-sm-6">
+                                <button type="submit" class="btn btn-primary" formaction="<?php echo Flight::get('base'); ?>/etl/save"><i class="fa fa-save"></i> Save Configuration</button>
+                                <?php if (!empty($etl_config['destination_db_id']) && !empty($etl_config['destination_table_name'])): ?>
+                                    <button type="submit" class="btn btn-success" formaction="<?php echo Flight::get('base'); ?>/etl/run"><i class="fa fa-play"></i> Run ETL Now</button>
+                                <?php endif; ?>
+                                <a href="<?php echo Flight::get('base'); ?>/dashboard" class="btn btn-default">Cancel</a>
+                            </div>
+                        </div>
+                    </form>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once 'includes/footer.php'; ?>

--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -54,8 +54,16 @@
         <br/>
 
         <ul class="sidebar-nav">
-            <?php echo Flight::get('tables'); ?>
-            <!-- Saved Queries link removed, queries are now shown on dashboard -->
+            <li><a href="<?php echo Flight::get('base'); ?>/dashboard"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="<?php echo Flight::get('base'); ?>/destinations"><i class="fa fa-rocket"></i> Manage Destinations</a></li>
+            <li class="nav-divider"></li>
+            <li class="nav-heading" style="padding: 10px 15px; font-weight: bold; color: #fff;">Tables</li>
+            <li style="padding: 0 15px;">
+                <select id="table_select" name="table_select" class="form-control" style="width: 230px;">
+                    <option value="">-- Choose a Table --</option>
+                    <?php echo Flight::get('table_options'); ?>
+                </select>
+            </li>
         </ul>
     </div>
     <!-- End Sidebar -->

--- a/app/views/table.php
+++ b/app/views/table.php
@@ -33,6 +33,9 @@
             <button type="button" class="btn btn-warning" id="btnShowTableFormatModal" style="margin-left: 10px;" data-query-id="<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>">
                 <i class="fa fa-paint-brush"></i> Format Table
             </button>
+            <a href="<?php echo Flight::get('base'); ?>/etl/<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-info" style="margin-left: 10px;">
+                <i class="fa fa-cogs"></i> ETL
+            </a>
         <?php endif; ?>
     </div>
     <div class="footer" id="generatedQueryDisplay">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -52,40 +52,33 @@ $('body').on('click', '#btnShowTableFormatModal', function() {
     $fieldsContainer.empty().append('<p class="text-center"><i class="fa fa-spinner fa-spin"></i> Loading columns...</p>');
     $msgContainer.hide().removeClass('alert-success alert-danger alert-info').text('');
 
-    // Fetch current column headers from the displayed table
-    var currentHeaders = [];
-    // Assuming the table is the one within div#tabledata and has a class like .dataTable or .table
-    // More robust selector might be needed if structure varies.
-    // We need the *original* headers, which are in the `<thead>` of the results table.
-    // The Presenter creates <th>OriginalName</th>
-
-    // Adjusted selector to correctly get headers from a DataTables-enhanced table,
-    // especially when scrollX is used (which clones headers).
+    // Fetch current column headers from the displayed table, now with data-original-name
+    var columns = [];
     var $tableInScrollHead = $('#tabledata .dataTables_scrollHead table.dataTable');
     var $thElements;
 
     if ($tableInScrollHead.length > 0) {
-        // If a scrolling header exists, use its th elements
         $thElements = $tableInScrollHead.find('thead tr:first-child th');
     } else {
-        // Otherwise, use the th elements from the main table directly within #tabledata
-        // This targets the first table found that has the class dataTable
         var $mainTable = $('#tabledata table.dataTable:first');
         if ($mainTable.length > 0) {
             $thElements = $mainTable.find('thead tr:first-child th');
         } else {
-            // Fallback to the original simpler selector if no dataTable class is found (should not happen for styled tables)
             $thElements = $('#tabledata table:first').find('thead tr:first-child th');
         }
     }
 
     if ($thElements && $thElements.length > 0) {
         $thElements.each(function() {
-            currentHeaders.push($(this).text());
+            var $th = $(this);
+            columns.push({
+                originalName: $th.data('original-name'),
+                displayName: $th.text()
+            });
         });
     }
 
-    if (currentHeaders.length === 0) {
+    if (columns.length === 0) {
         $fieldsContainer.empty().append('<p class="text-danger">Could not find table headers on the page.</p>');
         $modal.modal('show');
         return;
@@ -102,30 +95,25 @@ $('body').on('click', '#btnShowTableFormatModal', function() {
             if (response.status === 'success' && response.table_formatting && response.table_formatting.column_titles) {
                 existingColumnTitles = response.table_formatting.column_titles;
                  $msgContainer.addClass('alert-info').text('Loaded existing formatting.').show().delay(2000).fadeOut();
-            } else if (response.status !== 'success') {
-                 $msgContainer.addClass('alert-warning').text(response.message || 'Could not load existing formatting.').show();
+            } else if (response.status !== 'success' && response.message) {
+                 $msgContainer.addClass('alert-warning').text(response.message).show();
             }
-            // If no formatting, existingColumnTitles remains empty, so placeholders will be shown.
 
-            currentHeaders.forEach(function(originalHeader, index) {
-                // The 'name' attribute for inputs needs to be the original header to map correctly on save
-                // We need a way to get the *actual* original DB column name if the displayed header is already a custom one.
-                // For phase 1, the `originalHeader` is what `Presenter` used. If formatting was already applied,
-                // this `originalHeader` *is* the custom title. This is a problem.
-                // The `Presenter` needs to store original names if it's displaying custom ones.
-                //
-                // Workaround for Phase 1: We assume `currentHeaders` are the *original* database column names.
-                // This will be true if formatting has NOT YET been applied by a page reload.
-                // If formatting *has* been applied, this modal will show the *custom* titles as "Original".
-                // This is a limitation of Phase 1 based on current presenter.
-                // For now, let's assume `$(this).text()` from `<th>` is the key to use.
+            columns.forEach(function(column, index) {
+                if (!column.originalName) {
+                    console.warn("Skipping a column in formatting modal because it's missing 'data-original-name' attribute.");
+                    return; // a th without the attribute cannot be formatted
+                }
 
-                var inputId = 'th_format_' + index; // Use index for unique ID
-                var newTitle = existingColumnTitles[originalHeader] || ''; // Use originalHeader as key
+                var inputId = 'th_format_' + index;
+                // Look up the saved title using the *original* database column name
+                var savedTitle = existingColumnTitles[column.originalName] || '';
 
                 var fieldHtml = '<div class="form-group col-md-4">' +
-                                '<label for="' + inputId + '">Original: ' + escapeHtml(originalHeader) + '</label>' +
-                                '<input type="text" class="form-control" id="' + inputId + '" name="header_titles[' + escapeHtml(originalHeader) + ']" value="' + escapeHtml(newTitle) + '" placeholder="New Title (default: ' + escapeHtml(originalHeader) + ')">' +
+                                // The label shows the *currently displayed* name for user context
+                                '<label for="' + inputId + '">Current: ' + escapeHtml(column.displayName) + '</label>' +
+                                // The input's name attribute is the *original* name, which is the key for saving
+                                '<input type="text" class="form-control" id="' + inputId + '" name="header_titles[' + escapeHtml(column.originalName) + ']" value="' + escapeHtml(savedTitle) + '" placeholder="New Title (default: ' + escapeHtml(column.originalName) + ')">' +
                                 '</div>';
                 $fieldsContainer.append(fieldHtml);
             });
@@ -1119,6 +1107,14 @@ $(document).ready(function() {
     if (typeof initialSavedQueries !== 'undefined' && Array.isArray(initialSavedQueries)) {
         savedQueriesCache = initialSavedQueries;
     }
+
+    // handle table select dropdown change
+    $('#table_select').on('change', function () {
+        var url = $(this).val();
+        if (url) {
+            window.location.href = url;
+        }
+    });
 });
 
 function updateHavingFieldNameOptions() {

--- a/index.php
+++ b/index.php
@@ -111,8 +111,9 @@ foreach ($data as $datakey => $datavalue) {
 
 @file_put_contents('tables.json', json_encode($json));
 
-$tables = Presenter::listTables($data);
-Flight::set('tables', $tables);
+$table_options = Presenter::listTablesAsOptions($data);
+Flight::set('table_options', $table_options);
+//Flight::set('tables', ''); // Deprecate the old list view
 
 if (false !== strpos($_SERVER['REQUEST_URI'], '/table')) {
     $currentTableKey = array_search(Flight::get('lastSegment'), $data, true);

--- a/routes.php
+++ b/routes.php
@@ -12,6 +12,17 @@ Flight::route('POST /login', 'Login::loginuser');
 Flight::route('GET /login/logout', 'Login::logout');
 
 Flight::route('GET /dashboard', 'Dashboard::index');
+
+// Destination Management
+Flight::route('GET /destinations', 'Destinations::index');
+Flight::route('POST /destinations/add', 'Destinations::add');
+Flight::route('POST /destinations/delete', 'Destinations::delete');
+
+// ETL Configuration
+Flight::route('GET /etl/@query_id:[0-9]+', 'ETL::index');
+Flight::route('POST /etl/save', 'ETL::save');
+Flight::route('POST /etl/run', 'ETL::run');
+
 Flight::route('GET /export/csv', 'Export::csv');
 Flight::route('GET /export/excel', 'Export::excel');
 Flight::route('GET /table/[a-zA-Z0-9-_?+]+', 'Table::index');


### PR DESCRIPTION
This commit refactors the sidebar navigation to change the list of database tables from a simple `<ul>` list into a `<select>` dropdown menu. This improves the UI, especially for databases with a large number of tables.

Changes include:
- A new `listTablesAsOptions` method in the presenter to generate `<option>` tags.
- An update to `index.php` to call the new method and provide the options to the view.
- A modification to `app/views/includes/header.php` to replace the list with the new dropdown.
- A new JavaScript event listener in `custom.js` to handle navigation when a table is selected from the dropdown.