### PR TITLE
Feature: Add multi-data-source management and querying

### DIFF
--- a/app/controllers/DataSources.php
+++ b/app/controllers/DataSources.php
@@ -1,0 +1,66 @@
+<?php
+
+class DataSources
+{
+    private static $icon = 'fa fa-database';
+
+    public static function index()
+    {
+        self::checkLogin();
+
+        $sources = ORM::for_table('data_sources')->order_by_asc('source_name')->find_many();
+
+        Flight::render(
+            'datasources',
+            array(
+                'title' => 'Manage Data Sources',
+                'icon' => self::$icon,
+                'sources' => $sources
+            )
+        );
+    }
+
+    public static function add()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $source = ORM::for_table('data_sources')->create();
+            $source->source_name = $_POST['source_name'];
+            $source->db_host = $_POST['db_host'];
+            $source->db_port = $_POST['db_port'];
+            $source->db_name = $_POST['db_name'];
+            $source->db_user = $_POST['db_user'];
+            $source->db_password = toggleEncryption($_POST['db_password']);
+            $source->save();
+
+            setFlashMessage('Data source added successfully!');
+        }
+
+        Flight::redirect('/datasources');
+    }
+
+    public static function delete()
+    {
+        self::checkLogin();
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['id'])) {
+            $source = ORM::for_table('data_sources')->find_one($_POST['id']);
+            if ($source) {
+                $source->delete();
+                setFlashMessage('Data source deleted successfully!');
+            } else {
+                setFlashMessage('Error: Data source not found.', 'error');
+            }
+        }
+
+        Flight::redirect('/datasources');
+    }
+
+    private static function checkLogin()
+    {
+        if (!isset($_SESSION['logged'])) {
+            Flight::redirect('./login');
+        }
+    }
+}

--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -2,6 +2,61 @@
 
 class Ajax
 {
+    public static function set_data_source()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
+
+        if (isset($_POST['data_source_id'])) {
+            $_SESSION['selected_data_source'] = $_POST['data_source_id'];
+            $response['status'] = 'success';
+            $response['message'] = 'Data source set successfully.';
+        } else {
+            $response['message'] = 'Data source ID not provided.';
+        }
+
+        echo json_encode($response);
+    }
+
+    public static function get_tables_for_data_source()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.', 'tables' => []];
+
+        if (isset($_POST['data_source_id'])) {
+            $data_source_id = $_POST['data_source_id'];
+            $source = ORM::for_table('data_sources')->find_one($data_source_id);
+
+            if ($source) {
+                try {
+                    $password = toggleEncryption($source->db_password);
+
+                    // Create a temporary connection to the data source
+                    ORM::configure('mysql:host=' . $source->db_host . ';dbname=' . $source->db_name, null, 'temp_connection');
+                    ORM::configure('username', $source->db_user, 'temp_connection');
+                    ORM::configure('password', $password, 'temp_connection');
+
+                    $db = ORM::get_db('temp_connection');
+                    $stmt = $db->query('SHOW TABLES');
+                    $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+                    $response['status'] = 'success';
+                    $response['message'] = 'Tables retrieved successfully.';
+                    $response['tables'] = $tables;
+
+                } catch (PDOException $e) {
+                    $response['message'] = 'Database connection failed: ' . $e->getMessage();
+                }
+            } else {
+                $response['message'] = 'Data source not found.';
+            }
+        } else {
+            $response['message'] = 'Data source ID not provided.';
+        }
+
+        echo json_encode($response);
+    }
+
     /**
      * Gets fields/columns of specified table and generates dropdown options
      */

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -6,14 +6,41 @@ class Table
 {
     private static $icon = 'fa fa-table';
 
+    private static function get_data_source_connection_name()
+    {
+        if (isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source']) {
+            $data_source_id = $_SESSION['selected_data_source'];
+            $source = ORM::for_table('data_sources')->find_one($data_source_id);
+
+            if ($source) {
+                $connection_name = 'data_source_' . $source->id;
+                try {
+                    $password = toggleEncryption($source->db_password);
+
+                    ORM::configure('mysql:host=' . $source->db_host . ';dbname=' . $source->db_name, null, $connection_name);
+                    ORM::configure('username', $source->db_user, $connection_name);
+                    ORM::configure('password', $password, $connection_name);
+
+                    return $connection_name;
+                } catch (PDOException $e) {
+                    // fall back to default connection
+                    return ORM::DEFAULT_CONNECTION;
+                }
+            }
+        }
+
+        return ORM::DEFAULT_CONNECTION;
+    }
+
     public static function index($name)
     {
-
+        $connection_name = self::get_data_source_connection_name();
+        $db = ORM::get_db($connection_name);
         $table = Flight::get('lastSegment',$name);
     
         try {
             // Get table structure
-            $stmt = Flight::get('db')->query("DESCRIBE `$table`");
+            $stmt = $db->query("DESCRIBE `$table`");
             $table_fields_data = $stmt->fetchAll(PDO::FETCH_ASSOC); // Renamed to avoid conflict with $fields later
             // Pass the table name to getOptions to generate qualified field names
             $fieldOptions = getOptions(array_column($table_fields_data, 'Field'), false, $table);
@@ -39,14 +66,14 @@ class Table
         self::checkLogin();
 
         // enable query profiling
-        Flight::get('db')->query('SET profiling = 1;');
+        $db->query('SET profiling = 1;');
 
         // get specified table data as array
-        $records = ORM::for_table(Flight::get('lastSegment'))->find_array();
+        $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
         //pretty_print($records);
 
         // find out time above query was ran for
-        $exec_time_result = Flight::get('db')->query(
+        $exec_time_result = $db->query(
            'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
         );
 
@@ -113,6 +140,8 @@ class Table
 
     public static function run_saved_query()
     {
+        $connection_name = self::get_data_source_connection_name();
+        $db = ORM::get_db($connection_name);
         $query = $_POST['cquery'];
         $running_saved_query_name = $_POST['running_saved_query_name'] ?? null;
 
@@ -129,7 +158,7 @@ class Table
 
         // Get table columns
         try {
-            $stmt = Flight::get('db')->query("DESCRIBE `$tableName`");
+            $stmt = $db->query("DESCRIBE `$tableName`");
             $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
             $fields = array_column($columns, 'Field');
         } catch (PDOException $e) {
@@ -139,7 +168,7 @@ class Table
         }
 
         Flight::set('lastSegment', $tableName);
-        self::runQueryWithView($query, $fields, '', null, $running_saved_query_name);
+        self::runQueryWithView($query, $fields, '', null, $running_saved_query_name, $connection_name);
     }
 
     /**
@@ -147,6 +176,8 @@ class Table
      */
     public static function runquery()
     {
+        $connection_name = self::get_data_source_connection_name();
+        $db = ORM::get_db($connection_name);
         $printArray = '';
         $query = $_POST['cquery'];
 
@@ -155,7 +186,7 @@ class Table
         }
 
         // table columns
-        $stmt = Flight::get('db')->query("DESCRIBE " . Flight::get('lastSegment'));
+        $stmt = $db->query("DESCRIBE " . Flight::get('lastSegment'));
         $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
         //pretty_print($columns);
 
@@ -171,7 +202,7 @@ class Table
 
         // for custom query
         if ($query) {
-            self::runQueryWithView($query, $fields, $printArray, null, $running_saved_query_name);
+            self::runQueryWithView($query, $fields, $printArray, null, $running_saved_query_name, $connection_name);
 
         } // for visual query
         else {
@@ -227,7 +258,7 @@ class Table
                 }
             }
 
-            self::runQueryWithView($query, $fields, $printArray, $visual_params_for_view, $current_running_saved_query_name);
+            self::runQueryWithView($query, $fields, $printArray, $visual_params_for_view, $current_running_saved_query_name, $connection_name);
         }
 
     }
@@ -438,15 +469,20 @@ class Table
     }
 
 
-    private static function runQueryWithView($query, $fields, $printArray, $visual_query_params = null, $running_saved_query_name = null)
+    private static function runQueryWithView($query, $fields, $printArray, $visual_query_params = null, $running_saved_query_name = null, $connection_name = null)
     {
+        if (is_null($connection_name)) {
+            $connection_name = self::get_data_source_connection_name();
+        }
+        $db = ORM::get_db($connection_name);
+
         $_SESSION['tableData'] = array();
 
         $exec_time_row = array();
         $records = '';
 
         // Ensure tablesOptions is available for the view context by generating it directly
-        $_db = Flight::get('db');
+        $_db = $db;
         $tablesOptionsHtmlForView = '<option value="">Error loading tables (Controller Default)</option>'; // Default
         try {
             $allTablesStmt = $_db->query('SHOW TABLES');
@@ -468,12 +504,12 @@ class Table
 
         try {
             // turn on query profiling
-            Flight::get('db')->query('SET profiling = 1;');
+            $db->query('SET profiling = 1;');
 
-            $stmt = Flight::get('db')->query($query);
+            $stmt = $db->query($query);
 
             // find out time above query was ran for
-            $exec_time_result = Flight::get('db')->query(
+            $exec_time_result = $db->query(
                'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
             );
 

--- a/app/views/datasources.php
+++ b/app/views/datasources.php
@@ -1,0 +1,78 @@
+<?php require_once 'includes/header.php'; ?>
+
+<div class="page-content inset">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="panel panel-primary">
+                <div class="panel-heading">Add New Data Source</div>
+                <div class="panel-body">
+                    <form action="<?php echo Flight::get('base'); ?>/datasources/add" method="post" role="form">
+                        <div class="form-group">
+                            <label for="source_name">Source Name</label>
+                            <input type="text" class="form-control" id="source_name" name="source_name" placeholder="e.g., Production OLTP" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_host">Host</label>
+                            <input type="text" class="form-control" id="db_host" name="db_host" placeholder="e.g., 127.0.0.1" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_port">Port</label>
+                            <input type="number" class="form-control" id="db_port" name="db_port" placeholder="e.g., 3306" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_name">Database Name</label>
+                            <input type="text" class="form-control" id="db_name" name="db_name" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_user">Username</label>
+                            <input type="text" class="form-control" id="db_user" name="db_user" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="db_password">Password</label>
+                            <input type="password" class="form-control" id="db_password" name="db_password" required>
+                        </div>
+                        <button type="submit" class="btn btn-success"><i class="fa fa-plus"></i> Add Data Source</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="panel panel-default">
+                <div class="panel-heading">Existing Data Sources</div>
+                <div class="panel-body">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>Source Name</th>
+                                <th>Host</th>
+                                <th>Database</th>
+                                <th>User</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php if (isset($sources) && count($sources) > 0): ?>
+                                <?php foreach ($sources as $source): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($source->source_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($source->db_host, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($source->db_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($source->db_user, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td>
+                                            <form action="<?php echo Flight::get('base'); ?>/datasources/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this data source?');">
+                                                <input type="hidden" name="id" value="<?php echo $source->id; ?>">
+                                                <button type="submit" class="btn btn-danger btn-xs"><i class="fa fa-trash-o"></i> Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require_once 'includes/footer.php'; ?>

--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -49,8 +49,16 @@
 
         <ul class="sidebar-nav">
             <li><a href="<?php echo Flight::get('base'); ?>/dashboard"><i class="fa fa-dashboard"></i> Dashboard</a></li>
+            <li><a href="<?php echo Flight::get('base'); ?>/datasources"><i class="fa fa-database"></i> Manage Data Sources</a></li>
             <li><a href="<?php echo Flight::get('base'); ?>/destinations"><i class="fa fa-rocket"></i> Manage Destinations</a></li>
 
+            <li style="padding: 10px 15px;">
+                <label for="datasource" style="color: #fff; font-weight: bold;">Select Data Source</label>
+                <select name="datasource" id="datasource" class="form-control" style="width: 200px;">
+                    <option value="">-- Choose a Data Source --</option>
+                    <?php echo Flight::get('dataSourceOptions'); ?>
+                </select>
+            </li>
             <li class="nav-divider"></li>
 
             <li class="nav-heading" style="padding: 10px 15px; font-weight: bold; color: #fff;">Select Table</li>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1093,6 +1093,46 @@ $(document).ready(function() {
             window.location.href = url;
         }
     });
+
+    // handle data source select dropdown change
+    $('#datasource').on('change', function () {
+        var dataSourceId = $(this).val();
+        $.ajax({
+            url: base + '/ajax/set_data_source',
+            type: 'POST',
+            data: { data_source_id: dataSourceId },
+            success: function (response) {
+                if (response.status === 'success') {
+                    updateTableDropdown(dataSourceId);
+                }
+            }
+        });
+    });
+
+    function updateTableDropdown(dataSourceId) {
+        var $tableSelect = $('#table_select');
+        $tableSelect.empty().append('<option value="">Loading tables...</option>');
+
+        if (!dataSourceId) {
+            $tableSelect.empty().append('<option value="">-- Choose a Table --</option>');
+            return;
+        }
+
+        $.ajax({
+            url: base + '/ajax/get_tables_for_data_source',
+            type: 'POST',
+            data: { data_source_id: dataSourceId },
+            success: function (response) {
+                $tableSelect.empty().append('<option value="">-- Choose a Table --</option>');
+                if (response.status === 'success' && response.tables) {
+                    $.each(response.tables, function (index, table) {
+                        var url = base + '/table/' + table;
+                        $tableSelect.append('<option value="' + url + '">' + table + '</option>');
+                    });
+                }
+            }
+        });
+    }
 });
 
 function updateHavingFieldNameOptions() {

--- a/data_sources.sql
+++ b/data_sources.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `data_sources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `source_name` varchar(255) NOT NULL,
+  `db_host` varchar(255) NOT NULL,
+  `db_port` varchar(255) DEFAULT NULL,
+  `db_name` varchar(255) NOT NULL,
+  `db_user` varchar(255) NOT NULL,
+  `db_password` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/index.php
+++ b/index.php
@@ -135,6 +135,16 @@ if (false !== strpos($_SERVER['REQUEST_URI'], '/table')) {
 // set global variables
 Flight::set('appname', $config['appname']);
 
+// Get data sources for dropdown
+$data_sources = ORM::for_table('data_sources')->order_by_asc('source_name')->find_many();
+$dataSourceOptions = '';
+foreach ($data_sources as $source) {
+    $selected = (isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source'] == $source->id) ? 'selected' : '';
+    $dataSourceOptions .= "<option value=\"{$source->id}\" {$selected}>{$source->source_name}</option>";
+}
+Flight::set('dataSourceOptions', $dataSourceOptions);
+
+
 ///////// setup routes /////////////
 require_once 'routes.php';
 

--- a/routes.php
+++ b/routes.php
@@ -18,6 +18,11 @@ Flight::route('GET /destinations', 'Destinations::index');
 Flight::route('POST /destinations/add', 'Destinations::add');
 Flight::route('POST /destinations/delete', 'Destinations::delete');
 
+// Data Source Management
+Flight::route('GET /datasources', 'DataSources::index');
+Flight::route('POST /datasources/add', 'DataSources::add');
+Flight::route('POST /datasources/delete', 'DataSources::delete');
+
 // ETL Configuration
 Flight::route('GET /etl/@query_id:[0-9]+', 'ETL::index');
 Flight::route('POST /etl/save', 'ETL::save');
@@ -30,6 +35,8 @@ Flight::route('POST /table/run_saved_query', 'Table::run_saved_query');
 Flight::route('POST /table/[a-zA-Z0-9-_?+]+', 'Table::runquery');
 //Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', array('Ajax', Flight::get('lastSegment')));
 $lastSegment = Flight::get('lastSegment');
+Flight::route('POST /ajax/set_data_source', 'Ajax::set_data_source');
+Flight::route('POST /ajax/get_tables_for_data_source', 'Ajax::get_tables_for_data_source');
 Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries
 Flight::route('POST /ajax/saveTableFormatting', 'Ajax::saveTableFormatting'); // Route for saving table formatting


### PR DESCRIPTION
This change introduces a new feature that allows users to manage multiple data sources and run queries against them.

The new feature includes:
- A new `data_sources` table to store data source credentials.
- A "Manage Data Sources" page where users can add, view, and delete data sources.
- A data source selection dropdown in the header.
- Dynamic updating of the table list based on the selected data source.
- Backend logic to create database connections on the fly based on the selected data source.

Passwords for data sources are encrypted before being stored in the database.

This change also fixes the issue where running a saved query from the dashboard would fail.