### PR TITLE
feat: Associate saved queries with a specific data source

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -125,6 +125,7 @@ class Ajax
         // Use null coalescing and provide default empty string for trim if not set
         $query_name = trim($_POST['query_name'] ?? '');
         $sql_query = $_POST['sql_query'] ?? null;
+        $source_connection_id = $_POST['source_connection_id'] ?? null;
         $is_visual_query_provided = isset($_POST['is_visual_query']);
         $visual_params_provided = isset($_POST['visual_params']);
 
@@ -147,16 +148,18 @@ class Ajax
                 return;
             }
 
+            $has_source_connection_to_update = isset($_POST['source_connection_id']);
+
             // At least one field must be intended for update if query_id is present
-            if (!$has_name_to_update && !$has_sql_to_update && !$has_visual_to_update) {
+            if (!$has_name_to_update && !$has_sql_to_update && !$has_visual_to_update && !$has_source_connection_to_update) {
                  $response['message'] = 'No data provided to update for existing query.';
                  echo json_encode($response);
                  return;
             }
 
         } else { // This is a CREATE operation
-            if (empty($query_name) || empty($sql_query)) {
-                $response['message'] = 'For a new query, name and SQL query cannot be empty.';
+            if (empty($query_name) || empty($sql_query) || empty($source_connection_id)) {
+                $response['message'] = 'For a new query, name, SQL query and data source cannot be empty.';
                 echo json_encode($response);
                 return;
             }
@@ -177,6 +180,10 @@ class Ajax
                     }
                     if (isset($_POST['sql_query'])) {
                         $saved_query->sql_query = $sql_query;
+                        $updated_fields_count++;
+                    }
+                    if (isset($_POST['source_connection_id'])) {
+                        $saved_query->source_connection_id = $source_connection_id;
                         $updated_fields_count++;
                     }
                     if ($is_visual_query_provided) { // Update visual only if is_visual_query was part of the request
@@ -237,6 +244,7 @@ class Ajax
                 $saved_query = ORM::for_table('saved_queries')->create();
                 $saved_query->query_name = $query_name; // Already trimmed
                 $saved_query->sql_query = $sql_query; // Must be present due to earlier check
+                $saved_query->source_connection_id = $source_connection_id;
                 $saved_query->is_visual_query = $is_visual_query;
                 $saved_query->visual_params = $is_visual_query ? $visual_params : null;
                 // created_at is handled by database default

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -6,10 +6,15 @@ class Table
 {
     private static $icon = 'fa fa-table';
 
-    private static function get_data_source_connection_name()
+    private static function get_data_source_connection_name($data_source_id = null)
     {
-        if (isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source']) {
+        // Prioritize the explicitly passed data_source_id
+        if (is_null($data_source_id) && isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source']) {
+            // Fallback to session if no specific ID is provided
             $data_source_id = $_SESSION['selected_data_source'];
+        }
+
+        if ($data_source_id) {
             $source = ORM::for_table('data_sources')->find_one($data_source_id);
 
             if ($source) {
@@ -140,10 +145,14 @@ class Table
 
     public static function run_saved_query()
     {
-        $connection_name = self::get_data_source_connection_name();
-        $db = ORM::get_db($connection_name);
         $query = $_POST['cquery'];
         $running_saved_query_name = $_POST['running_saved_query_name'] ?? null;
+
+        $saved_query = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
+        $source_connection_id = $saved_query ? $saved_query->source_connection_id : null;
+
+        $connection_name = self::get_data_source_connection_name($source_connection_id);
+        $db = ORM::get_db($connection_name);
 
         // Extract table name from query
         $matches = [];
@@ -606,6 +615,7 @@ class Table
             if ($saved_query_details) {
                 $view_data['executed_query_id'] = $saved_query_details->id;
                 $view_data['executed_query_name'] = $saved_query_details->query_name;
+                $view_data['executed_query_source_connection_id'] = $saved_query_details->source_connection_id;
                 $view_data['executed_query_was_saved_visual'] = (bool)$saved_query_details->is_visual_query;
                 // If it was a saved visual query, its visual_params should be used for editing,
                 // overriding any ad-hoc VQB params that might have been used to run it (though less likely for "Run Saved Query")

--- a/app/views/includes/modals.php
+++ b/app/views/includes/modals.php
@@ -407,6 +407,12 @@ $fields = $fields ?? [];
                     <label for="query_name_save">Query Name:</label>
                     <input type="text" class="form-control" id="query_name_save" name="query_name_save" required>
                 </div>
+                <div class="form-group">
+                    <label for="source_connection_id_save">Data Source:</label>
+                    <select class="form-control" id="source_connection_id_save" name="source_connection_id_save" required>
+                        <?php echo Flight::get('dataSourceOptionsUnselected'); ?>
+                    </select>
+                </div>
                 <input type="hidden" id="sql_query_save" name="sql_query_save">
             </div>
             <div class="modal-footer">

--- a/app/views/table.php
+++ b/app/views/table.php
@@ -14,6 +14,25 @@
     <div style="margin-bottom: 10px;">
         <h3 style="display: inline-block; margin-right: 10px;">Generated Query</h3>
         <button type="button" class="btn btn-success" id="btnShowSaveQueryModal"><i class="fa fa-save"></i> Save Current Query</button>
+        <?php if (isset($executed_query_id) && !empty($executed_query_id)): ?>
+            <div style="display: inline-block; margin-left: 15px;">
+                <label for="executed_query_source_connection_id_display" style="font-weight: bold;">Data Source:</label>
+                <select class="form-control" id="executed_query_source_connection_id_display" name="executed_query_source_connection_id_display" style="width: 200px; display: inline-block;" disabled>
+                    <?php
+                        // Re-create options with the correct one selected
+                        $options = Flight::get('dataSourceOptionsUnselected');
+                        if (isset($executed_query_source_connection_id)) {
+                            $options = str_replace(
+                                'value="' . $executed_query_source_connection_id . '"',
+                                'value="' . $executed_query_source_connection_id . '" selected',
+                                $options
+                            );
+                        }
+                        echo $options;
+                    ?>
+                </select>
+            </div>
+        <?php endif; ?>
         <?php
             // Determine if the "Edit Query" button should be shown.
             // Option 1: Query was just built with VQB (visual_params_json is set from current VQB run)

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1342,6 +1342,15 @@ $('body').on('click', '#btnShowSaveQueryModal', function() {
     $('#sql_query_save').val(sqlQueryText);
     $('#query_name_save').val(''); // Always clear name for a new save
 
+    // Pre-select the data source in the modal if it's displayed on the page
+    var displayedSourceId = $('#executed_query_source_connection_id_display').val();
+    if (displayedSourceId) {
+        $('#source_connection_id_save').val(displayedSourceId);
+    } else {
+        // If not on a saved query page, ensure the modal dropdown is reset to default
+        $('#source_connection_id_save').val('');
+    }
+
     // For saving visual query params
     var visualParamsJsonString = $('#current_visual_params').val();
     if (visualParamsJsonString && visualParamsJsonString !== '') {
@@ -1377,6 +1386,7 @@ $('body').on('click', '#btnShowSaveQueryModal', function() {
 $('body').on('click', '#btnSaveQueryConfirm', function() {
     var queryName = $('#query_name_save').val();
     var sqlQuery = $('#sql_query_save').val();
+    var sourceConnectionId = $('#source_connection_id_save').val();
     var $saveQueryMsg = $('#saveQueryMsg');
     var visualParams = $('#modal-save-query').data('visual-params');
 
@@ -1390,12 +1400,18 @@ $('body').on('click', '#btnSaveQueryConfirm', function() {
         return;
     }
 
+    if ($.trim(sourceConnectionId) === '') {
+        $saveQueryMsg.removeClass('alert-success').addClass('alert-danger').text('Please select a data source.').show();
+        return;
+    }
+
     var $thisButton = $(this);
     $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
 
     var ajaxData = {
         query_name: queryName,
         sql_query: sqlQuery,
+        source_connection_id: sourceConnectionId,
         is_visual_query: (visualParams && visualParams !== '') ? true : false,
         visual_params: (visualParams && visualParams !== '') ? visualParams : null
     };

--- a/index.php
+++ b/index.php
@@ -143,6 +143,13 @@ foreach ($data_sources as $source) {
 }
 Flight::set('dataSourceOptions', $dataSourceOptions);
 
+// Also create a generic, unselected list of data sources for modals
+$dataSourceOptionsUnselected = '<option value="">-- Choose Data Source --</option>';
+foreach ($data_sources as $source) {
+    $dataSourceOptionsUnselected .= "<option value=\"{$source->id}\">{$source->source_name}</option>";
+}
+Flight::set('dataSourceOptionsUnselected', $dataSourceOptionsUnselected);
+
 
 ///////// setup routes /////////////
 require_once 'routes.php';


### PR DESCRIPTION
This feature modifies the saved query functionality to associate each query with a specific data source.

Key changes:
- Adds a `source_connection_id` column to the `saved_queries` table.
- The "Save Query" modal now includes a mandatory "Data Source" dropdown.
- The backend logic is updated to save the selected `source_connection_id` when a query is created or updated.
- When a saved query is executed, the system now uses the `source_connection_id` stored with the query to establish the database connection, rather than relying on the global session-based data source.
- The query results page now displays the data source that was used to run the query. This dropdown is disabled to indicate it is for display purposes, but its value is used to pre-populate the "Save Query" modal if the user decides to save a modified version of the query.