### PR TITLE
feat: Associate saved queries with a specific data source and fix rel…

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -187,7 +187,7 @@ class Ajax
                         $updated_fields_count++;
                     }
                     if ($is_visual_query_provided) { // Update visual only if is_visual_query was part of the request
-                        $saved_query->is_visual_query = $is_visual_query;
+                        $saved_query->is_visual_query = (int)$is_visual_query;
                         $saved_query->visual_params = $is_visual_query ? $visual_params : null;
                         $updated_fields_count++;
 
@@ -245,7 +245,7 @@ class Ajax
                 $saved_query->query_name = $query_name; // Already trimmed
                 $saved_query->sql_query = $sql_query; // Must be present due to earlier check
                 $saved_query->source_connection_id = $source_connection_id;
-                $saved_query->is_visual_query = $is_visual_query;
+                $saved_query->is_visual_query = (int)$is_visual_query;
                 $saved_query->visual_params = $is_visual_query ? $visual_params : null;
                 // created_at is handled by database default
 

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -138,7 +138,6 @@ class Table
               'title' => Flight::get('lastSegment'), // This is $table
               'icon' => self::$icon,
               'table_data' => $records,
-
               'query' => SqlFormatter::format($the_query),
               'timetaken' => $exec_time_row[0][1],
               'view_tables_options_html' => $tablesOptionsHtmlForView


### PR DESCRIPTION
…ated bugs

This feature modifies the saved query functionality to associate each query with a specific data source. It also includes fixes for three bugs identified during development:
1. The table list in the side panel was incorrectly showing tables from the application's internal database.
2. The "Generated Query" display was showing an incorrect query or was empty.
3. Saving a non-visual query resulted in a database error due to an incorrect data type for `is_visual_query`.

Key changes:
- Adds a `source_connection_id` column to the `saved_queries` table.
- The "Save Query" modal now includes a mandatory "Data Source" dropdown.
- The backend logic is updated to save the selected `source_connection_id` when a query is created or updated.
- When a saved query is executed, the system now uses the `source_connection_id` stored with the query to establish the database connection.
- The query results page now displays the data source that was used to run the query.
- The side panel table list is now correctly populated from the currently selected data source.
- The "Generated Query" text on the table view page now correctly displays the query run against the data source.
- The `is_visual_query` value is now correctly cast to an integer before being saved to the database.