### PR TITLE
feat: Associate saved queries with a specific data source and fix rel…

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1340,7 +1340,13 @@ $('body').on('click', '#btnShowSaveQueryModal', function() {
     }
 
     $('#sql_query_save').val(sqlQueryText);
-    $('#query_name_save').val(''); // Always clear name for a new save
+
+    var executedQueryName = $('#executed_query_name').val();
+    if (executedQueryName) {
+        $('#query_name_save').val(executedQueryName + ' (copy)');
+    } else {
+        $('#query_name_save').val(''); // Clear name for a new save
+    }
 
     // Pre-select the data source in the modal if it's displayed on the page
     var displayedSourceId = $('#executed_query_source_connection_id_display').val();


### PR DESCRIPTION
…ated bugs

This feature modifies the saved query functionality to associate each query with a specific data source. It also includes fixes for several bugs identified during development:
1. The table list in the side panel was incorrectly showing tables from the application's internal database.
2. The "Generated Query" display was showing an incorrect query or was empty.
3. Saving a non-visual query resulted in a database error due to an incorrect data type for `is_visual_query`.
4. The "Save Current Query" modal was not pre-populated with the existing query's name and data source when viewing a saved query.

Key changes:
- Adds a `source_connection_id` column to the `saved_queries` table.
- The "Save Query" modal now includes a mandatory "Data Source" dropdown.
- The backend logic is updated to save the selected `source_connection_id` when a query is created or updated.
- When a saved query is executed, the system now uses the `source_connection_id` stored with the query to establish the database connection.
- The query results page now displays the data source that was used to run the query.
- The "Save Current Query" modal is now pre-populated with the existing query's name (with a "(copy)" suffix) and data source for a better "Save As" workflow.
- The side panel table list is now correctly populated from the currently selected data source.
- The "Generated Query" text on the table view page now correctly displays the query run against the data source.
- The `is_visual_query` value is now correctly cast to an integer before being saved to the database.