### PR TITLE
feat: Associate saved queries with data source and implement upsert l…

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -618,6 +618,12 @@ class Table
                 $view_data['executed_query_id'] = $saved_query_details->id;
                 $view_data['executed_query_name'] = $saved_query_details->query_name;
                 $view_data['executed_query_source_connection_id'] = $saved_query_details->source_connection_id;
+                if ($saved_query_details->source_connection_id) {
+                    $source = ORM::for_table('data_sources')->find_one($saved_query_details->source_connection_id);
+                    if ($source) {
+                        $view_data['executed_query_source_name'] = $source->source_name;
+                    }
+                }
                 $view_data['executed_query_was_saved_visual'] = (bool)$saved_query_details->is_visual_query;
                 // If it was a saved visual query, its visual_params should be used for editing,
                 // overriding any ad-hoc VQB params that might have been used to run it (though less likely for "Run Saved Query")

--- a/app/views/table.php
+++ b/app/views/table.php
@@ -16,21 +16,8 @@
         <button type="button" class="btn btn-success" id="btnShowSaveQueryModal"><i class="fa fa-save"></i> Save Current Query</button>
         <?php if (isset($executed_query_id) && !empty($executed_query_id)): ?>
             <div style="display: inline-block; margin-left: 15px;">
-                <label for="executed_query_source_connection_id_display" style="font-weight: bold;">Data Source:</label>
-                <select class="form-control" id="executed_query_source_connection_id_display" name="executed_query_source_connection_id_display" style="width: 200px; display: inline-block;" disabled>
-                    <?php
-                        // Re-create options with the correct one selected
-                        $options = Flight::get('dataSourceOptionsUnselected');
-                        if (isset($executed_query_source_connection_id)) {
-                            $options = str_replace(
-                                'value="' . $executed_query_source_connection_id . '"',
-                                'value="' . $executed_query_source_connection_id . '" selected',
-                                $options
-                            );
-                        }
-                        echo $options;
-                    ?>
-                </select>
+                <strong style="font-weight: bold;">Data Source:</strong>
+                <span style="margin-left: 5px;"><?php echo htmlspecialchars($executed_query_source_name ?? 'N/A', ENT_QUOTES, 'UTF-8'); ?></span>
             </div>
         <?php endif; ?>
         <?php
@@ -73,6 +60,7 @@
     <!-- Holds info about the executed query IF it was a saved query that was run -->
     <input type="hidden" id="executed_query_id" value="<?php echo isset($executed_query_id) ? htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8') : ''; ?>">
     <input type="hidden" id="executed_query_name" value="<?php echo isset($executed_query_name) ? htmlspecialchars($executed_query_name, ENT_QUOTES, 'UTF-8') : ''; ?>">
+    <input type="hidden" id="executed_query_source_connection_id" value="<?php echo isset($executed_query_source_connection_id) ? htmlspecialchars($executed_query_source_connection_id, ENT_QUOTES, 'UTF-8') : ''; ?>">
     <!-- This flag helps JS determine if the #current_visual_params are from a saved visual query context vs an ad-hoc VQB run -->
     <input type="hidden" id="executed_query_was_saved_visual" value="<?php echo (isset($executed_query_was_saved_visual) && $executed_query_was_saved_visual) ? 'true' : 'false'; ?>">
 

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1349,7 +1349,7 @@ $('body').on('click', '#btnShowSaveQueryModal', function() {
     }
 
     // Pre-select the data source in the modal if it's displayed on the page
-    var displayedSourceId = $('#executed_query_source_connection_id_display').val();
+    var displayedSourceId = $('#executed_query_source_connection_id').val();
     if (displayedSourceId) {
         $('#source_connection_id_save').val(displayedSourceId);
     } else {


### PR DESCRIPTION
…ogic

This feature modifies the saved query functionality to associate each query with a specific data source and changes the save behavior to an "upsert" model.

Key changes:
- Adds a `source_connection_id` column to the `saved_queries` table.
- The "Save Query" modal now includes a mandatory "Data Source" dropdown.
- The backend `saveQuery` logic now performs an "upsert":
  - If a query is saved with a name that already exists, it is updated.
  - If the name is new, a new query is created.
- When a saved query is executed, the system now uses the `source_connection_id` stored with the query to establish the database connection.
- The query results page now displays the data source name as read-only text.
- The "Save Current Query" modal is now pre-populated with the existing query's name and data source to facilitate an "update" or "save as" workflow.

This also includes fixes for several bugs identified during development:
- The table list in the side panel now correctly shows tables from the selected data source.
- The "Generated Query" display is now correctly populated.
- A database error when saving non-visual queries has been resolved.