### PR TITLE
feat: Associate saved queries with data source and improve UI workflows

### DIFF
--- a/app/views/includes/footer.php
+++ b/app/views/includes/footer.php
@@ -57,6 +57,16 @@
 
     // set font size
     document.getElementById('ace').style.fontSize = '13px';
+
+    // Handler to populate the editor when the modal is opened
+    $('body').on('click', 'a[data-target="#modal-custom-query"], button[data-target="#modal-custom-query"]', function() {
+        var currentQuery = $('#generatedQueryDisplay pre').text();
+        if (currentQuery && $.trim(currentQuery) !== '') {
+            editor.setValue($.trim(currentQuery), 1); // 1 moves cursor to the end
+        } else {
+            editor.setValue('', -1); // -1 moves cursor to the start and clears editor
+        }
+    });
 </script>
 
 <script>


### PR DESCRIPTION
This feature modifies the saved query functionality to associate each query with a specific data source and improves several related user workflows.

Key changes:
- Adds a `source_connection_id` column to the `saved_queries` table.
- The "Save Query" modal now includes a mandatory "Data Source" dropdown.
- The backend `saveQuery` logic now performs an "upsert":
  - If a query is saved with a name that already exists, it is updated.
  - If the name is new, a new query is created.
- When a saved query is executed, the system now uses the `source_connection_id` stored with the query to establish the database connection.
- The query results page now displays the data source name as read-only text.
- The "Save Current Query" modal is now pre-populated with the existing query's name and data source to facilitate an "update" or "save as" workflow.
- The "Custom Query" modal is now pre-populated with the SQL from the currently viewed query results page.

This also includes fixes for several bugs identified during development:
- The table list in the side panel now correctly shows tables from the selected data source.
- The "Generated Query" display is now correctly populated.
- A database error when saving non-visual queries has been resolved.