### PR TITLE
Fix: Add 'Edit Custom SQL' button to query results page

### DIFF
--- a/app/views/table.php
+++ b/app/views/table.php
@@ -34,6 +34,8 @@
         ?>
         <?php if ($can_edit_visually): ?>
             <button type="button" class="btn btn-info" id="btnEditExecutedQuery" style="margin-left: 10px;"><i class="fa fa-pencil"></i> Edit Query in VQB</button>
+        <?php elseif (isset($executed_query_id) && !empty($executed_query_id)): ?>
+            <button type="button" class="btn btn-info" id="btnEditCustomSQL" style="margin-left: 10px;"><i class="fa fa-pencil"></i> Edit Custom SQL</button>
         <?php endif; ?>
         <?php if (isset($executed_query_id) && !empty($executed_query_id)): ?>
             <button type="button" class="btn btn-warning" id="btnShowTableFormatModal" style="margin-left: 10px;" data-query-id="<?php echo htmlspecialchars($executed_query_id, ENT_QUOTES, 'UTF-8'); ?>">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -787,6 +787,33 @@ $('body').on('click', '#btnEditExecutedQuery', function() {
     }
 });
 
+// --- Edit Custom SQL Query Button (from query results page) ---
+$('body').on('click', '#btnEditCustomSQL', function() {
+    var executedQueryId = $('#executed_query_id').val();
+    var sqlQueryText = $('#generatedQueryDisplay pre').text();
+
+    if (!executedQueryId) {
+        $.jGrowl('Error: Executed query ID not found.', { header: 'Error' });
+        return;
+    }
+
+    // Populate the hidden input in the custom query modal
+    $('#custom_query_id_edit').val(executedQueryId);
+
+    // Set the ACE editor's content
+    if (typeof editor !== 'undefined' && editor !== null) {
+        editor.setValue(sqlQueryText, -1); // -1 moves cursor to the start
+    } else {
+        // Fallback if ACE editor is not ready, though it should be.
+        // The modal might not be visible yet, but we can try to set a textarea if one existed.
+        // For now, we rely on the editor being available when the modal is shown.
+        console.warn('ACE editor instance not found when trying to set SQL for editing.');
+    }
+
+    // Show the modal
+    $('#modal-custom-query').modal('show');
+});
+
 
 // --- Helper functions (initializeVisualQueryBuilder, initializeVisualQueryForm, setupJoinRow, openAsSQLQuery) ---
 // These were part of the older structure and are now largely replaced or integrated into openVisualQueryBuilderModal


### PR DESCRIPTION
This commit fixes a bug where updating a saved custom query from the results page would fail with a 'Query ID is missing' error.

The root cause was the absence of a mechanism to open the custom query modal in an 'edit' state from the results page. This meant the query ID was never passed to the modal.

This change introduces an 'Edit Custom SQL' button on the query results page, which is visible only for non-visual saved queries. A new JavaScript handler populates the modal with the correct query ID and SQL content before displaying it, resolving the error and allowing users to update their custom queries directly from the results page.