### PR TITLE
Feat: Improve query editing flow and add page refresh

### DIFF
--- a/app/views/includes/header.php
+++ b/app/views/includes/header.php
@@ -92,10 +92,6 @@
                            class="fa fa-database"></i> Visual Query
                     </button>
 
-                    <button rel="hover_popover" data-content="Type Custom Query" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#modal-custom-query">
-                        <i
-                           class="fa fa-pencil-square-o"></i> Custom Query
-                    </button>
                 <?php } ?>
 
                 <a rel="hover_popover" data-content="Log Out" href="<?php echo Flight::get(

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -948,8 +948,9 @@ $('body').on('click', '#btnUpdateVisualQuery', function() {
                         // itemInCache.sql_query = new_sql_query_from_server;
                     }
                 }
-                // Optionally close the modal
-                // $modal.modal('hide');
+                setTimeout(function() {
+                    location.reload();
+                }, 1500);
             } else {
                 $.jGrowl(response.message || 'An error occurred while updating the query.', { header: 'Error', theme: 'error', life: 5000 });
             }
@@ -1022,8 +1023,7 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
                 // }
 
                 setTimeout(function() {
-                    $msgContainer.fadeOut(function() { $(this).hide(); });
-                    $('#modal-custom-query').modal('hide');
+                    location.reload();
                 }, 1500);
             } else {
                 $msgContainer.removeClass('alert-success').addClass('alert-danger').text(response.message || 'An unknown error occurred.').show();
@@ -1472,8 +1472,8 @@ $('body').on('click', '#btnSaveQueryConfirm', function() {
 
 
                 setTimeout(function() {
-                    $saveQueryMsg.fadeOut();
-                }, 3000);
+                    location.reload();
+                }, 1500);
             } else {
                 $saveQueryMsg.removeClass('alert-success').addClass('alert-danger').text(response.message || 'An unknown error occurred.').show();
             }


### PR DESCRIPTION
This commit includes several improvements to the query management workflow.

First, it fixes a bug that caused a 'Query ID is missing' error when updating a custom SQL query from its results page. This was resolved by adding a new context-aware 'Edit Custom SQL' button to the results page, which correctly prepares the editing modal.

Second, based on user feedback, the page will now automatically refresh after any query is saved or updated, ensuring the user sees the most current state.

Third, the generic 'Custom Query' button has been removed from the main application header, streamlining the UI and favoring more contextual actions.