### PR TITLE
Feat: Enhance query workflow and fix display/update bugs

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -138,7 +138,7 @@ class Table
               'title' => Flight::get('lastSegment'), // This is $table
               'icon' => self::$icon,
               'table_data' => $records,
-              'query' => SqlFormatter::format($the_query),
+              'query' => $the_query,
               'timetaken' => $exec_time_row[0][1],
               'view_tables_options_html' => $tablesOptionsHtmlForView
            )
@@ -601,7 +601,7 @@ class Table
             'icon' => self::$icon,
             'table_data' => $records,
             'fields' => getOptions($fields, false, Flight::get('lastSegment')), // Pass table name for field dropdowns
-            'query' => SqlFormatter::format($query),
+            'query' => $query,
             'printArray' => $printArray,
             'timetaken' => $exec_time_row[0][1] ?? '0.00', // Ensure timetaken has a default
             'view_tables_options_html' => $tablesOptionsHtmlForView // Use the locally generated one

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -948,9 +948,8 @@ $('body').on('click', '#btnUpdateVisualQuery', function() {
                         // itemInCache.sql_query = new_sql_query_from_server;
                     }
                 }
-                setTimeout(function() {
-                    location.reload();
-                }, 1500);
+                // Optionally close the modal
+                // $modal.modal('hide');
             } else {
                 $.jGrowl(response.message || 'An error occurred while updating the query.', { header: 'Error', theme: 'error', life: 5000 });
             }
@@ -1022,9 +1021,27 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
                 //    $listItem.find('.btn-edit-saved-query, .btn-delete-saved-query').data('query-name', queryName);
                 // }
 
-                setTimeout(function() {
-                    location.reload();
-                }, 1500);
+                // Re-run the query to show updated results
+                var updatedQuery = (typeof editor !== 'undefined' && editor !== null) ? editor.getValue() : sqlQuery;
+                var queryName = $('#executed_query_name').val(); // This is on the table results page
+
+                var formAction = base + '/table/run_saved_query';
+                var $dynamicForm = $('<form>', {
+                    'action': formAction,
+                    'method': 'POST',
+                    'style': 'display:none;'
+                }).append($('<input>', {
+                    'type': 'hidden',
+                    'name': 'cquery',
+                    'value': updatedQuery
+                })).append($('<input>', {
+                    'type': 'hidden',
+                    'name': 'running_saved_query_name',
+                    'value': queryName
+                }));
+
+                $('body').append($dynamicForm);
+                $dynamicForm.submit();
             } else {
                 $msgContainer.removeClass('alert-success').addClass('alert-danger').text(response.message || 'An unknown error occurred.').show();
             }
@@ -1472,8 +1489,8 @@ $('body').on('click', '#btnSaveQueryConfirm', function() {
 
 
                 setTimeout(function() {
-                    location.reload();
-                }, 1500);
+                    $saveQueryMsg.fadeOut();
+                }, 3000);
             } else {
                 $saveQueryMsg.removeClass('alert-success').addClass('alert-danger').text(response.message || 'An unknown error occurred.').show();
             }


### PR DESCRIPTION
This commit introduces a comprehensive set of improvements and bug fixes to the query management workflow, addressing several issues identified by the user.

- Fix: Update Saved Query from Results Page
  - Resolves a bug that caused a 'Query ID is missing' error when attempting to update a custom SQL query from the results page.
  - A new context-aware 'Edit Custom SQL' button has been added to the results page for non-visual queries. This button correctly populates the editing modal with the necessary query ID and SQL content.

- Fix: Show Updated Results After Saving a Query
  - Corrects a logic bug where reloading the page after an update would show the old query's results.
  - The success handler for query updates now dynamically creates and submits a form containing the newly modified SQL. This ensures the user is immediately shown the results of their updated query.

- Fix: Display Raw SQL in Generated Query Panel
  - Removes the `SqlFormatter` from the query display logic. The 'Generated Query' panel now shows the raw, single-line SQL statement, as requested.

- Refactor: Streamline UI by Removing Header Button
  - The generic 'Custom Query' button has been removed from the main application header. This encourages a more contextual workflow, where editing is initiated from the query results page.