### PR TITLE
This commit fixes several issues related to the 'Edit Query' workflow…

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -148,10 +148,23 @@ class Table
     public static function run_saved_query()
     {
         $query = $_POST['cquery'];
+        $query_id = $_POST['query_id'] ?? null;
         $running_saved_query_name = $_POST['running_saved_query_name'] ?? null;
+        $saved_query = null;
 
-        $saved_query = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
-        $source_connection_id = $saved_query ? $saved_query->source_connection_id : null;
+        if ($query_id) {
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+        } elseif ($running_saved_query_name) {
+            $saved_query = ORM::for_table('saved_queries')->where('query_name', $running_saved_query_name)->find_one();
+        }
+
+        // If we have a saved query model, we can derive the name and connection ID
+        if ($saved_query) {
+            $running_saved_query_name = $saved_query->query_name;
+            $source_connection_id = $saved_query->source_connection_id;
+        } else {
+            $source_connection_id = null;
+        }
 
         $connection_name = self::get_data_source_connection_name($source_connection_id);
         $db = ORM::get_db($connection_name);

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1012,6 +1012,7 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
         success: function(response) {
             if (response.status === 'success') {
                 $msgContainer.removeClass('alert-danger').addClass('alert-success').text(response.message).show();
+                var source = $('#modal-custom-query').data('source'); // Read source immediately
 
                 // Update cache for sql_query
                 var queryName = '';
@@ -1024,7 +1025,6 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
                 }
 
                 setTimeout(function() {
-                    var source = $('#modal-custom-query').data('source');
                     if (source === 'dashboard') {
                         location.reload(); // Just reload the dashboard
                     } else {
@@ -1039,8 +1039,8 @@ $('body').on('click', '#btnUpdateSavedQuery', function() {
                             'value': sqlQuery
                         })).append($('<input>', {
                             'type': 'hidden',
-                            'name': 'running_saved_query_name',
-                            'value': queryName
+                            'name': 'query_id',
+                            'value': queryId
                         }));
 
                         $('body').append($dynamicForm);


### PR DESCRIPTION
… to align with user requirements and improve robustness.

1. The 'Edit' button on the dashboard now correctly populates the SQL editor with the saved query's content.

2. The 'Save' button in the edit modal now has conditional behavior. When editing from the dashboard, it reloads the dashboard. When editing from the results page, it re-runs the query. This is managed by a `data-source` flag on the modal.

3. The logic for re-running the query is now more robust. The backend (`run_saved_query`) was refactored to look up queries by `query_id` instead of by name. The frontend was updated to send the `query_id` in a dynamic form, fixing a flaw in the previous implementation.