### PR TITLE
Previously, the Visual Query Builder (VQB) only supported updating ex…

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -116,6 +116,47 @@ class Ajax
         echo $html;
     }
 
+    public static function getSqlFromVisualParams()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
+
+        $visual_params_json = $_POST['visual_params'] ?? null;
+        $primary_table_name = $_POST['primary_table_name'] ?? null;
+
+        if (!$visual_params_json || !$primary_table_name) {
+            $response['message'] = 'Missing required parameters (visual_params or primary_table_name).';
+            echo json_encode($response);
+            return;
+        }
+
+        $params_array = json_decode($visual_params_json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            $response['message'] = 'Invalid JSON in visual_params.';
+            echo json_encode($response);
+            return;
+        }
+
+        try {
+            // Ensure Table class is available
+            if (class_exists('Table')) {
+                $generated_sql = Table::generateSqlFromVisualParams($params_array, $primary_table_name);
+                $response['status'] = 'success';
+                $response['message'] = 'SQL generated successfully.';
+                $response['sql_query'] = $generated_sql;
+            } else {
+                $response['message'] = 'Table class not found.';
+                error_log("Ajax::getSqlFromVisualParams - Table class not found.");
+            }
+        } catch (Exception $e) {
+            $response['message'] = 'Error during SQL generation: ' . $e->getMessage();
+            error_log("Ajax::getSqlFromVisualParams - Exception: " . $e->getMessage());
+        }
+
+        echo json_encode($response);
+    }
+
     public static function saveQuery()
     {
         header('Content-Type: application/json');

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -849,125 +849,119 @@ function initializeVisualQueryBuilder(parsedParams, sqlQuery, queryName) {
 $('body').on('click', '#btnUpdateVisualQuery', function() {
     var $modal = $('#modal-visual-query');
     var queryId = $modal.find('#visual_query_id_edit').val();
+    var $thisButton = $(this);
 
-    if (!queryId) {
-        $.jGrowl('Error: Query ID is missing. Cannot update.', { header: 'Error', theme: 'error' });
-        return;
-    }
-
-    // Collect form data
+    // Collect form data into a structured object
     var formData = $modal.find('form').serializeArray();
     var visualParamsData = {};
-
-    // Process serialized array into a structured object, handling multi-value fields
     formData.forEach(function(item) {
-        // Check if item name ends with [], indicating an array
         if (item.name.endsWith('[]')) {
             var name = item.name.substring(0, item.name.length - 2);
             if (!visualParamsData[name]) {
                 visualParamsData[name] = [];
             }
-            if (item.value) { // Only push non-empty values for array fields
+            if (item.value) {
                 visualParamsData[name].push(item.value);
             }
         } else {
-            // For single value fields, only set if value is not empty,
-            // or if it's a field that can legitimately be empty (like chkDescending if not checked - but serializeArray doesn't include unchecked boxes)
-            // For simplicity here, we take all values. Specific handling for empty optional fields might be needed if they cause issues.
             if (item.value || item.name === 'chkDescending' || item.name === 'limitStart' || item.name === 'limitNumRows') {
-                 // explicitly include chkDescending even if its value might be "on" or undefined
-                if(item.name === 'chkDescending' && !$modal.find('input[name="chkDescending"]').is(':checked')){
-                    // Ensure 'chkDescending' is not added if not checked, or set to a specific false value if required by backend
-                    // For now, we'll let it be absent if not checked. If present, serializeArray gives its value.
-                } else {
+                if(item.name === 'chkDescending' && !$modal.find('input[name="chkDescending"]').is(':checked')){} else {
                     visualParamsData[item.name] = item.value;
                 }
             }
         }
     });
-
-    // Ensure array fields that might be empty are at least empty arrays
     var arrayFields = ['fields', 'agg_field', 'agg_func', 'agg_alias', 'jointype', 'jointable', 'joinfield', 'joinfieldp', 'ftype', 'fname', 'fvalue', 'groupfields', 'orderfields', 'htype', 'hfname', 'hfvalue'];
     arrayFields.forEach(function(fieldName) {
         if (!visualParamsData[fieldName]) {
             visualParamsData[fieldName] = [];
         }
     });
-
-    // Handle checkbox for chkDescending specifically as serializeArray doesn't include it if unchecked
     if ($modal.find('input[name="chkDescending"]').is(':checked')) {
-        visualParamsData.chkDescending = 'on'; // Or true, depending on what backend expects
+        visualParamsData.chkDescending = 'on';
     } else {
-        delete visualParamsData.chkDescending; // Remove if not checked, or set to false/0
+        delete visualParamsData.chkDescending;
     }
-
-
-    // Add primaryTable
     if (typeof __table !== 'undefined' && __table) {
         visualParamsData.primaryTable = __table;
-    } else {
-        console.warn('VQB Update: __table is not defined. primaryTable will not be included in visual_params.');
     }
-
-    // Remove the hidden input visual_query_id_edit from params sent to server
-    // as it's not part of the actual visual query structure
     if ('visual_query_id_edit' in visualParamsData){
         delete visualParamsData.visual_query_id_edit;
     }
-    if ('visual_query_id_edit_submit' in visualParamsData){ // also remove the other one if present
+    if ('visual_query_id_edit_submit' in visualParamsData){
         delete visualParamsData.visual_query_id_edit_submit;
     }
-
-
     var visualParamsJsonString = JSON.stringify(visualParamsData);
 
-    console.log("Updating Visual Query ID:", queryId);
-    console.log("Visual Params to save:", visualParamsJsonString);
-
-    var $thisButton = $(this);
-    $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
-
-    // AJAX call to save/update the query
-    $.ajax({
-        url: base + '/ajax/saveQuery',
-        type: 'POST',
-        data: {
-            query_id: queryId,
-            visual_params: visualParamsJsonString,
-            is_visual_query: true
-            // We are not sending sql_query here. The backend should ideally handle
-            // updating/clearing the SQL query if visual_params change, or the SQL could become stale.
-            // query_name is also not updated here; that's handled by a separate modal.
-        },
-        dataType: 'json',
-        success: function(response) {
-            if (response.status === 'success') {
-                $.jGrowl(response.message || 'Visual query updated successfully!', { header: 'Success', theme: 'success', life: 3000 });
-
-                // Update cache if it exists
-                if (typeof savedQueriesCache !== 'undefined' && savedQueriesCache.find) {
-                    var itemInCache = savedQueriesCache.find(function(q) { return q.id == queryId; });
-                    if (itemInCache) {
-                        itemInCache.visual_params = visualParamsJsonString;
-                        itemInCache.is_visual_query = true;
-                        // If sql_query was also updated and returned by server, update it here too.
-                        // itemInCache.sql_query = new_sql_query_from_server;
+    if (queryId) {
+        // --- EXISTING QUERY: UPDATE IT ---
+        $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
+        $.ajax({
+            url: base + '/ajax/saveQuery',
+            type: 'POST',
+            data: {
+                query_id: queryId,
+                visual_params: visualParamsJsonString,
+                is_visual_query: true
+            },
+            dataType: 'json',
+            success: function(response) {
+                if (response.status === 'success') {
+                    $.jGrowl(response.message || 'Visual query updated successfully!', { header: 'Success', theme: 'success', life: 3000 });
+                    if (typeof savedQueriesCache !== 'undefined' && savedQueriesCache.find) {
+                        var itemInCache = savedQueriesCache.find(function(q) { return q.id == queryId; });
+                        if (itemInCache) {
+                            itemInCache.visual_params = visualParamsJsonString;
+                            itemInCache.is_visual_query = true;
+                        }
                     }
+                    setTimeout(function() {
+                        location.reload();
+                    }, 1500);
+                } else {
+                    $.jGrowl(response.message || 'An error occurred while updating the query.', { header: 'Error', theme: 'error', life: 5000 });
                 }
-                setTimeout(function() {
-                    location.reload();
-                }, 1500);
-            } else {
-                $.jGrowl(response.message || 'An error occurred while updating the query.', { header: 'Error', theme: 'error', life: 5000 });
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                $.jGrowl('AJAX Error: ' + textStatus + ' - ' + errorThrown, { header: 'AJAX Error', theme: 'error', life: 5000 });
+            },
+            complete: function() {
+                $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-save');
             }
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-            $.jGrowl('AJAX Error: ' + textStatus + ' - ' + errorThrown, { header: 'AJAX Error', theme: 'error', life: 5000 });
-        },
-        complete: function() {
-            $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-save');
-        }
-    });
+        });
+    } else {
+        // --- NEW QUERY: GENERATE SQL AND OPEN SAVE MODAL ---
+        $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');
+        $.ajax({
+            url: base + '/ajax/getSqlFromVisualParams',
+            type: 'POST',
+            data: {
+                visual_params: JSON.stringify(visualParamsData),
+                primary_table_name: visualParamsData.primaryTable
+            },
+            dataType: 'json',
+            success: function(response) {
+                if (response.status === 'success' && response.sql_query) {
+                    // Hide VQB modal
+                    $modal.modal('hide');
+                    // Now open the Save Query modal, populating it with the generated SQL and visual params
+                    $('#sql_query_save').val(response.sql_query);
+                    $('#query_name_save').val(''); // Clear name for a new save
+                    $('#modal-save-query').data('visual-params', visualParamsJsonString); // Attach visual params for saving
+                    $('#saveQueryMsg').hide().removeClass('alert-success alert-danger').text('');
+                    $('#modal-save-query').modal('show');
+                } else {
+                    $.jGrowl(response.message || 'Could not generate SQL for this visual query.', { header: 'Error', theme: 'error' });
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                $.jGrowl('AJAX Error generating SQL: ' + textStatus, { header: 'AJAX Error', theme: 'error' });
+            },
+            complete: function() {
+                 $thisButton.prop('disabled', false).find('i').removeClass('fa-spinner fa-spin').addClass('fa-save');
+            }
+        });
+    }
 });
 
 // --- Update Saved Query (from Custom Query Modal) ---

--- a/routes.php
+++ b/routes.php
@@ -37,6 +37,7 @@ Flight::route('POST /table/[a-zA-Z0-9-_?+]+', 'Table::runquery');
 $lastSegment = Flight::get('lastSegment');
 Flight::route('POST /ajax/set_data_source', 'Ajax::set_data_source');
 Flight::route('POST /ajax/get_tables_for_data_source', 'Ajax::get_tables_for_data_source');
+Flight::route('POST /ajax/getSqlFromVisualParams', 'Ajax::getSqlFromVisualParams');
 Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries
 Flight::route('POST /ajax/saveTableFormatting', 'Ajax::saveTableFormatting'); // Route for saving table formatting


### PR DESCRIPTION
…isting queries. Attempting to save a new visual query resulted in an error because no query ID was present.

This commit introduces a new workflow for saving new visual queries:
1. A new AJAX endpoint, `/ajax/getSqlFromVisualParams`, was created to generate SQL from VQB data.
2. The 'Update Visual Query' button in the VQB modal now checks for a query ID.
3. If no ID exists, it calls the new endpoint to get the generated SQL and then opens the standard 'Save Query' modal, pre-populated with the data.
4. If an ID exists, the original update logic is preserved.