### PR TITLE
Fix: Resolve Javascript scope issue for updateTableDropdown

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1112,40 +1112,40 @@ $(document).ready(function() {
             }
         });
     });
+});
 
-    function updateTableDropdown(dataSourceId, callback) {
-        var $tableSelect = $('#table_select');
-        $tableSelect.empty().append('<option value="">Loading tables...</option>');
+function updateTableDropdown(dataSourceId, callback) {
+    var $tableSelect = $('#table_select');
+    $tableSelect.empty().append('<option value="">Loading tables...</option>');
 
-        if (!dataSourceId) {
+    if (!dataSourceId) {
+        $tableSelect.empty().append('<option value="">-- Choose a Table --</option>');
+        if (typeof callback === 'function') {
+            callback();
+        }
+        return;
+    }
+
+    $.ajax({
+        url: base + '/ajax/get_tables_for_data_source',
+        type: 'POST',
+        data: { data_source_id: dataSourceId },
+        success: function (response) {
             $tableSelect.empty().append('<option value="">-- Choose a Table --</option>');
+            if (response.status === 'success' && response.tables) {
+                $.each(response.tables, function (index, table) {
+                    var url = base + '/table/' + table;
+                    $tableSelect.append('<option value="' + url + '">' + table + '</option>');
+                });
+            }
+        },
+        complete: function() {
             if (typeof callback === 'function') {
                 callback();
             }
-            return;
         }
-
-        $.ajax({
-            url: base + '/ajax/get_tables_for_data_source',
-            type: 'POST',
-            data: { data_source_id: dataSourceId },
-            success: function (response) {
-                $tableSelect.empty().append('<option value="">-- Choose a Table --</option>');
-                if (response.status === 'success' && response.tables) {
-                    $.each(response.tables, function (index, table) {
-                        var url = base + '/table/' + table;
-                        $tableSelect.append('<option value="' + url + '">' + table + '</option>');
-                    });
-                }
-            },
-            complete: function() {
-                if (typeof callback === 'function') {
-                    callback();
-                }
-            }
-        });
-    }
-});
+    });
+}
 
 function updateHavingFieldNameOptions() {
     var options = [];


### PR DESCRIPTION
This commit fixes a Javascript error `Uncaught ReferenceError: updateTableDropdown is not defined` that occurred when editing a saved query.

The `updateTableDropdown` function was moved from within the `$(document).ready()` block to the global scope. This makes it accessible to the `.btn-edit-saved-query` click handler, which needs to call it.

This change is a follow-up to the previous commit that pre-selects the data source when editing a saved query.