### PR TITLE
Feat: Replace ETL destination table input with a dropdown

### DIFF
--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -694,4 +694,37 @@ class Ajax
 
         echo json_encode($response);
     }
+
+    public static function get_destination_tables()
+    {
+        header('Content-Type: application/json');
+
+        if (!isset($_POST['destination_id']) || empty($_POST['destination_id'])) {
+            echo json_encode(array('status' => 'error', 'message' => 'Destination ID is required.'));
+            return;
+        }
+
+        $destination_id = $_POST['destination_id'];
+
+        try {
+            $destination_db = ORM::for_table('destination_databases')->find_one($destination_id);
+
+            if (!$destination_db) {
+                throw new Exception("Destination database not found.");
+            }
+
+            $decrypted_password = toggleEncryption($destination_db->db_password);
+            $dsn = "mysql:host={$destination_db->db_host};port={$destination_db->db_port};dbname={$destination_db->db_name};charset=utf8";
+            $pdo = new PDO($dsn, $destination_db->db_user, $decrypted_password);
+            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            $stmt = $pdo->query("SHOW TABLES");
+            $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+            echo json_encode(array('status' => 'success', 'tables' => $tables));
+
+        } catch (Exception $e) {
+            echo json_encode(array('status' => 'error', 'message' => 'Error: ' . $e->getMessage()));
+        }
+    }
 }

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -39,9 +39,11 @@
                         <div class="form-group">
                             <label for="destination_table" class="col-sm-3 control-label">Destination Table Name</label>
                             <div class="col-sm-6">
-                                <input type="text" class="form-control" id="destination_table" name="destination_table"
-                                       placeholder="e.g., daily_sales_summary"
-                                       value="<?php echo isset($etl_config['destination_table_name']) ? htmlspecialchars($etl_config['destination_table_name'], ENT_QUOTES, 'UTF-8') : ''; ?>" required>
+                                <select class="form-control" id="destination_table" name="destination_table"
+                                        data-saved-table="<?php echo isset($etl_config['destination_table_name']) ? htmlspecialchars($etl_config['destination_table_name'], ENT_QUOTES, 'UTF-8') : ''; ?>"
+                                        required disabled>
+                                    <option value="">-- Select a Destination First --</option>
+                                </select>
                                 <p class="help-block">The table where the query results will be inserted. The table must exist.</p>
                             </div>
                         </div>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1112,6 +1112,49 @@ $(document).ready(function() {
             }
         });
     });
+
+    // ETL Page: Handle destination change to populate tables
+    $('#destination_id').on('change', function() {
+        var destinationId = $(this).val();
+        var $tableSelect = $('#destination_table');
+        var savedTableName = $tableSelect.data('saved-table');
+
+        if (!destinationId) {
+            $tableSelect.html('<option value="">-- Select a Destination First --</option>').prop('disabled', true);
+            return;
+        }
+
+        $tableSelect.html('<option value="">Loading tables...</option>').prop('disabled', false);
+
+        $.ajax({
+            url: base + '/ajax/get_destination_tables',
+            type: 'POST',
+            data: { destination_id: destinationId },
+            dataType: 'json',
+            success: function(response) {
+                $tableSelect.empty();
+                if (response.status === 'success' && response.tables) {
+                    $tableSelect.append('<option value="">-- Select a Table --</option>');
+                    $.each(response.tables, function(index, table) {
+                        var selected = (table === savedTableName) ? ' selected' : '';
+                        $tableSelect.append('<option value="' + escapeHtml(table) + '"' + selected + '>' + escapeHtml(table) + '</option>');
+                    });
+                } else {
+                    $tableSelect.html('<option value="">Could not load tables</option>');
+                    $.jGrowl(response.message || 'An error occurred.', { header: 'Error', theme: 'error' });
+                }
+            },
+            error: function() {
+                $tableSelect.html('<option value="">Error loading tables</option>');
+                $.jGrowl('An AJAX error occurred while fetching tables.', { header: 'Error', theme: 'error' });
+            }
+        });
+    });
+
+    // Trigger change on page load if a destination is already selected
+    if ($('#destination_id').val()) {
+        $('#destination_id').trigger('change');
+    }
 });
 
 function updateTableDropdown(dataSourceId, callback) {

--- a/routes.php
+++ b/routes.php
@@ -37,6 +37,7 @@ Flight::route('POST /table/[a-zA-Z0-9-_?+]+', 'Table::runquery');
 $lastSegment = Flight::get('lastSegment');
 Flight::route('POST /ajax/set_data_source', 'Ajax::set_data_source');
 Flight::route('POST /ajax/get_tables_for_data_source', 'Ajax::get_tables_for_data_source');
+Flight::route('POST /ajax/get_destination_tables', 'Ajax::get_destination_tables');
 Flight::route('POST /ajax/getSqlFromVisualParams', 'Ajax::getSqlFromVisualParams');
 Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries


### PR DESCRIPTION
This commit changes the ETL page to display a dropdown of tables from the selected destination database, instead of a text input field.

- Replaced the 'Destination Table Name' text input with a `<select>` dropdown in `app/views/etl.php`.
- Added a new AJAX endpoint `get_destination_tables` in `app/controllers/ajax.php` to fetch tables from a given destination ID.
- Added a new route for this endpoint in `routes.php`.
- Added JavaScript to `assets/js/custom.js` to handle the change event on the destination dropdown. When a destination is selected, it populates the table dropdown with the tables from that destination via an AJAX call.
- The Javascript also handles pre-selecting the saved table on page load.