### PR TITLE
feat: Implement ETL column mapping

### DIFF
--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -50,9 +50,16 @@ class ETL
             $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
 
             if ($saved_query) {
+                $column_mapping = $_POST['column_mapping'] ?? [];
+                // Filter out any columns that were not mapped
+                $filtered_mapping = array_filter($column_mapping, function($value) {
+                    return $value !== '';
+                });
+
                 $etl_config = array(
                     'destination_db_id' => $destination_id,
-                    'destination_table_name' => $destination_table
+                    'destination_table_name' => $destination_table,
+                    'column_mapping' => $filtered_mapping
                 );
 
                 $saved_query->etl_config = json_encode($etl_config);
@@ -116,18 +123,31 @@ class ETL
             }
 
             // 4. Prepare and Insert Data into Destination
-            $columns = array_keys($source_data[0]);
-            $column_list = '`' . implode('`, `', $columns) . '`';
-            $placeholders = rtrim(str_repeat('?,', count($columns)), ',');
+            $etl_config = json_decode($saved_query->etl_config, true);
+            $column_mapping = $etl_config['column_mapping'] ?? [];
+
+            if (empty($column_mapping)) {
+                throw new Exception("No column mapping defined. Please save a configuration.");
+            }
+
+            // Filter source data to only include columns that are in the mapping
+            $mapped_source_columns = array_keys($column_mapping);
+            $destination_columns = array_values($column_mapping);
+
+            $column_list = '`' . implode('`, `', $destination_columns) . '`';
+            $placeholders = rtrim(str_repeat('?,', count($destination_columns)), ',');
 
             $insert_sql = "INSERT INTO `{$destination_table}` ({$column_list}) VALUES ({$placeholders})";
 
             $dest_pdo->beginTransaction();
-
             $insert_stmt = $dest_pdo->prepare($insert_sql);
 
             foreach ($source_data as $row) {
-                $insert_stmt->execute(array_values($row));
+                $ordered_row_values = [];
+                foreach ($mapped_source_columns as $source_col) {
+                    $ordered_row_values[] = $row[$source_col];
+                }
+                $insert_stmt->execute($ordered_row_values);
             }
 
             $dest_pdo->commit();

--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -727,4 +727,61 @@ class Ajax
             echo json_encode(array('status' => 'error', 'message' => 'Error: ' . $e->getMessage()));
         }
     }
+
+    public static function get_etl_mapping_data()
+    {
+        header('Content-Type: application/json');
+        $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
+
+        try {
+            if (!isset($_POST['query_id']) || !isset($_POST['destination_table']) || !isset($_POST['destination_id'])) {
+                throw new Exception("Missing required parameters: query_id, destination_table, and destination_id are required.");
+            }
+
+            $query_id = $_POST['query_id'];
+            $destination_table = $_POST['destination_table'];
+            $destination_id = $_POST['destination_id'];
+
+            // 1. Get Source Columns from the SQL query
+            $saved_query = ORM::for_table('saved_queries')->find_one($query_id);
+            if (!$saved_query) {
+                throw new Exception("Saved query not found.");
+            }
+
+            $source_pdo = Flight::get('db');
+            // Appending LIMIT 0 is a common trick to get metadata without fetching rows
+            $source_stmt = $source_pdo->prepare($saved_query->sql_query . " LIMIT 0");
+            $source_stmt->execute();
+            $source_columns = [];
+            for ($i = 0; $i < $source_stmt->columnCount(); $i++) {
+                $col_meta = $source_stmt->getColumnMeta($i);
+                $source_columns[] = $col_meta['name'];
+            }
+
+            // 2. Get Destination Columns from the destination table
+            $destination_db_details = ORM::for_table('destination_databases')->find_one($destination_id);
+            if (!$destination_db_details) {
+                throw new Exception("Destination database configuration not found.");
+            }
+            $decrypted_password = toggleEncryption($destination_db_details->db_password);
+            $dsn = "mysql:host={$destination_db_details->db_host};port={$destination_db_details->db_port};dbname={$destination_db_details->db_name};charset=utf8";
+            $dest_pdo = new PDO($dsn, $destination_db_details->db_user, $decrypted_password);
+            $dest_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+            // Using DESCRIBE is a reliable way to get column names
+            $dest_stmt = $dest_pdo->query("DESCRIBE `{$destination_table}`");
+            $destination_columns = $dest_stmt->fetchAll(PDO::FETCH_COLUMN);
+
+            $response = [
+                'status' => 'success',
+                'source_columns' => $source_columns,
+                'destination_columns' => $destination_columns
+            ];
+
+        } catch (Exception $e) {
+            $response['message'] = 'Error: ' . $e->getMessage();
+        }
+
+        echo json_encode($response);
+    }
 }

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -36,6 +36,15 @@
                             </div>
                         </div>
 
+                        <hr>
+                        <h4>Column Mapping:</h4>
+                        <div id="column-mapping-container" class="col-sm-offset-1 col-sm-10">
+                            <p class="text-muted">Select a destination table to map columns.</p>
+                        </div>
+                        <div class="clearfix"></div>
+                        <hr>
+
+
                         <div class="form-group">
                             <label for="destination_table" class="col-sm-3 control-label">Destination Table Name</label>
                             <div class="col-sm-6">
@@ -64,5 +73,10 @@
         </div>
     </div>
 </div>
+
+<script>
+    // Pass the PHP etl_config to JavaScript
+    var etlConfig = <?php echo json_encode($etl_config); ?>;
+</script>
 
 <?php require_once 'includes/footer.php'; ?>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1155,6 +1155,70 @@ $(document).ready(function() {
     if ($('#destination_id').val()) {
         $('#destination_id').trigger('change');
     }
+
+    // ETL Page: Handle destination TABLE change to populate column mapping
+    $('#destination_table').on('change', function() {
+        var destinationTable = $(this).val();
+        var destinationId = $('#destination_id').val();
+        var queryId = $('input[name="query_id"]').val();
+        var $mappingContainer = $('#column-mapping-container');
+
+        if (!destinationTable) {
+            $mappingContainer.html('<p class="text-muted">Select a destination table to map columns.</p>');
+            return;
+        }
+
+        $mappingContainer.html('<p><i class="fa fa-spinner fa-spin"></i> Loading column mapping...</p>');
+
+        $.ajax({
+            url: base + '/ajax/get_etl_mapping_data',
+            type: 'POST',
+            data: {
+                query_id: queryId,
+                destination_table: destinationTable,
+                destination_id: destinationId
+            },
+            dataType: 'json',
+            success: function(response) {
+                if (response.status === 'success') {
+                    var html = '<div class="row">';
+                    html += '<div class="col-sm-6"><strong>Source Column (from Query)</strong></div>';
+                    html += '<div class="col-sm-6"><strong>Destination Column (from Table)</strong></div>';
+                    html += '</div><hr style="margin-top: 5px; margin-bottom: 10px;">';
+
+                    response.source_columns.forEach(function(sourceCol) {
+                        html += '<div class="form-group row">';
+                        html += '  <div class="col-sm-6">';
+                        html += '    <input type="text" class="form-control" value="' + escapeHtml(sourceCol) + '" readonly>';
+                        html += '  </div>';
+                        html += '  <div class="col-sm-6">';
+                        html += '    <select class="form-control" name="column_mapping[' + escapeHtml(sourceCol) + ']">';
+                        html += '      <option value="">-- Do Not Map --</option>';
+                        response.destination_columns.forEach(function(destCol) {
+                            var savedMapping = (typeof etlConfig !== 'undefined' && etlConfig.column_mapping) ? etlConfig.column_mapping[sourceCol] : null;
+                            var selected = (destCol === savedMapping || destCol === sourceCol) ? ' selected' : '';
+                            html += '<option value="' + escapeHtml(destCol) + '"' + selected + '>' + escapeHtml(destCol) + '</option>';
+                        });
+                        html += '    </select>';
+                        html += '  </div>';
+                        html += '</div>';
+                    });
+
+                    $mappingContainer.html(html);
+                } else {
+                    $mappingContainer.html('<p class="text-danger">Error: ' + response.message + '</p>');
+                }
+            },
+            error: function() {
+                $mappingContainer.html('<p class="text-danger">An AJAX error occurred while fetching column data.</p>');
+            }
+        });
+    });
+
+    // Trigger change on ETL page load if a destination table is already selected
+    if ($('#destination_table').val()) {
+        $('#destination_table').trigger('change');
+    }
 });
 
 function updateTableDropdown(dataSourceId, callback) {

--- a/routes.php
+++ b/routes.php
@@ -38,6 +38,7 @@ $lastSegment = Flight::get('lastSegment');
 Flight::route('POST /ajax/set_data_source', 'Ajax::set_data_source');
 Flight::route('POST /ajax/get_tables_for_data_source', 'Ajax::get_tables_for_data_source');
 Flight::route('POST /ajax/get_destination_tables', 'Ajax::get_destination_tables');
+Flight::route('POST /ajax/get_etl_mapping_data', 'Ajax::get_etl_mapping_data');
 Flight::route('POST /ajax/getSqlFromVisualParams', 'Ajax::getSqlFromVisualParams');
 Flight::route('POST /ajax/[a-zA-Z0-9-_?+]+', 'Ajax::'.$lastSegment);
 Flight::route('GET /ajax/getSavedQueries', 'Ajax::getSavedQueries'); // Route for fetching saved queries


### PR DESCRIPTION
This feature introduces a column mapping interface on the ETL configuration page.

- When a destination table is selected, a grid is now displayed.
- The left column of the grid shows the field names from the saved SQL query.
- The right column provides a dropdown for each source field, allowing the user to select a corresponding field from the ETL destination table.
- This mapping is saved along with the ETL configuration.
- The ETL execution process now uses this mapping to insert data into the correct columns in the destination table.