### PR TITLE
refactor: Reorder ETL page UI elements

### DIFF
--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -36,15 +36,6 @@
                             </div>
                         </div>
 
-                        <hr>
-                        <h4>Column Mapping:</h4>
-                        <div id="column-mapping-container" class="col-sm-offset-1 col-sm-10">
-                            <p class="text-muted">Select a destination table to map columns.</p>
-                        </div>
-                        <div class="clearfix"></div>
-                        <hr>
-
-
                         <div class="form-group">
                             <label for="destination_table" class="col-sm-3 control-label">Destination Table Name</label>
                             <div class="col-sm-6">
@@ -56,6 +47,14 @@
                                 <p class="help-block">The table where the query results will be inserted. The table must exist.</p>
                             </div>
                         </div>
+
+                        <hr>
+                        <h4>Column Mapping:</h4>
+                        <div id="column-mapping-container" class="col-sm-offset-1 col-sm-10">
+                            <p class="text-muted">Select a destination table to map columns.</p>
+                        </div>
+                        <div class="clearfix"></div>
+                        <hr>
 
                         <div class="form-group">
                             <div class="col-sm-offset-3 col-sm-6">


### PR DESCRIPTION
This commit adjusts the layout of the ETL configuration page for a better user experience.

The 'Column Mapping' section has been moved to appear directly below the 'Destination Table Name' selection dropdown. This provides a more logical and intuitive workflow for the user, as the column mapping is dependent on the selected table.