### PR TITLE
fix: Resolve race condition on ETL page load

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1139,6 +1139,11 @@ $(document).ready(function() {
                         var selected = (table === savedTableName) ? ' selected' : '';
                         $tableSelect.append('<option value="' + escapeHtml(table) + '"' + selected + '>' + escapeHtml(table) + '</option>');
                     });
+
+                    // If a table was selected (from saved config), trigger its change event to load the column mapper
+                    if ($tableSelect.val()) {
+                        $tableSelect.trigger('change');
+                    }
                 } else {
                     $tableSelect.html('<option value="">Could not load tables</option>');
                     $.jGrowl(response.message || 'An error occurred.', { header: 'Error', theme: 'error' });
@@ -1214,11 +1219,6 @@ $(document).ready(function() {
             }
         });
     });
-
-    // Trigger change on ETL page load if a destination table is already selected
-    if ($('#destination_table').val()) {
-        $('#destination_table').trigger('change');
-    }
 });
 
 function updateTableDropdown(dataSourceId, callback) {


### PR DESCRIPTION
This commit fixes a bug that prevented the destination table and column mapping from being displayed on page load after being saved.

The issue was a race condition in the JavaScript where the check to display the column mapping was running before the asynchronous call to populate the destination table dropdown had completed.

The fix involves:
- Removing the incorrectly placed event trigger for the destination table.
- Moving the event trigger into the `success` callback of the AJAX call that populates the destination table dropdown.

This ensures that the column mapping section is only rendered after the destination table has been selected, correctly restoring the saved state on page load.