### PR TITLE
fix: Use correct source database connection in ETL run

### DIFF
--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -111,7 +111,16 @@ class ETL
             $dest_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
             // 3. Fetch Source Data
-            $source_pdo = Flight::get('db');
+            $source_db_details = ORM::for_table('data_sources')->find_one($saved_query->source_connection_id);
+            if (!$source_db_details) {
+                throw new Exception("Source database configuration for this query not found.");
+            }
+
+            $source_decrypted_password = toggleEncryption($source_db_details->db_password);
+            $source_dsn = "mysql:host={$source_db_details->db_host};port={$source_db_details->db_port};dbname={$source_db_details->db_name};charset=utf8";
+            $source_pdo = new PDO($source_dsn, $source_db_details->db_user, $source_decrypted_password);
+            $source_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
             $source_stmt = $source_pdo->prepare($saved_query->sql_query);
             $source_stmt->execute();
             $source_data = $source_stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
This commit fixes a critical bug where the 'Run ETL Now' functionality was using the application's default database connection to execute the source query, instead of the data source specified in the saved query's configuration. This resulted in 'Table not found' errors if the source table did not exist in the default database.

The `run` method in `app/controllers/ETL.php` has been updated to:
- Retrieve the `source_connection_id` from the saved query.
- Fetch the connection details for that data source.
- Establish a new PDO connection to the correct source database.
- Use this correct connection to execute the source query and fetch the data for the ETL process.

This ensures the ETL process runs using the correct database connections for both source and destination.