### PR TITLE
fix: Correct DataTables initialization for empty ETL log

### DIFF
--- a/app/views/etl_log.php
+++ b/app/views/etl_log.php
@@ -33,10 +33,6 @@
                                         <td><pre><?php echo htmlspecialchars($log->message, ENT_QUOTES, 'UTF-8'); ?></pre></td>
                                     </tr>
                                 <?php endforeach; ?>
-                            <?php else: ?>
-                                <tr>
-                                    <td colspan="5" class="text-center">No ETL logs found.</td>
-                                </tr>
                             <?php endif; ?>
                         </tbody>
                     </table>


### PR DESCRIPTION
This commit fixes a JavaScript error on the ETL Log page that occurred when the log table was empty. The error was caused by an incompatibility between the DataTables library and the custom "No logs found" row, which used a `colspan`.

The fix removes the custom row and instead renders a standard `<tbody>` which is empty when there are no logs. This allows the DataTables library to initialize correctly and display its default "No data available in table" message, resolving the error.