### PR TITLE
feat: Add detailed scheduling options for ETL jobs

### DIFF
--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -59,24 +59,37 @@ class ETL
                     return $value !== '';
                 });
 
-                $schedule_type = $_POST['schedule_type'] ?? 'inactive';
-                $schedule_interval = $_POST['schedule_interval'] ?? '5';
-
-                // Get existing config to preserve other settings like last_run_at
+                // Get existing config to preserve settings not on this form (like last_run_at)
                 $etl_config = $saved_query->etl_config ? json_decode($saved_query->etl_config, true) : [];
 
+                // Always save these base settings
                 $etl_config['destination_db_id'] = $destination_id;
                 $etl_config['destination_table_name'] = $destination_table;
                 $etl_config['etl_type'] = $etl_type;
                 $etl_config['column_mapping'] = $filtered_mapping;
                 $etl_config['key_columns'] = $key_columns;
+
+                // --- New Scheduling Logic ---
+                $schedule_type = $_POST['schedule_type'] ?? 'inactive';
                 $etl_config['schedule_type'] = $schedule_type;
 
-                if ($schedule_type === 'minutely') {
-                    $etl_config['schedule_interval'] = $schedule_interval;
-                } else {
-                    // Remove interval if not minutely to keep config clean
-                    unset($etl_config['schedule_interval']);
+                // Unset all possible schedule-specific keys to ensure a clean save
+                unset($etl_config['schedule_interval']);
+                unset($etl_config['schedule_hours']);
+                unset($etl_config['schedule_days']);
+
+                // Set the specific schedule options based on the selected type
+                switch ($schedule_type) {
+                    case 'minutely':
+                        $etl_config['schedule_interval'] = $_POST['schedule_interval'] ?? '5';
+                        break;
+                    case 'hourly':
+                        $etl_config['schedule_hours'] = $_POST['schedule_hours'] ?? [];
+                        break;
+                    case 'daily':
+                        $etl_config['schedule_days'] = $_POST['schedule_days'] ?? [];
+                        break;
+                    // For 'inactive' and 'weekly', no extra params are needed
                 }
 
                 $saved_query->etl_config = json_encode($etl_config);

--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -75,16 +75,52 @@
                                     <option value="hourly" <?php echo (isset($etl_config['schedule_type']) && $etl_config['schedule_type'] == 'hourly') ? 'selected' : ''; ?>>Hourly</option>
                                     <option value="daily" <?php echo (isset($etl_config['schedule_type']) && $etl_config['schedule_type'] == 'daily') ? 'selected' : ''; ?>>Daily</option>
                                     <option value="weekly" <?php echo (isset($etl_config['schedule_type']) && $etl_config['schedule_type'] == 'weekly') ? 'selected' : ''; ?>>Weekly</option>
-                                    <option value="monthly" <?php echo (isset($etl_config['schedule_type']) && $etl_config['schedule_type'] == 'monthly') ? 'selected' : ''; ?>>Monthly</option>
                                 </select>
                             </div>
                         </div>
 
-                        <div class="form-group" id="schedule_interval_group" style="display:none;">
-                            <label for="schedule_interval" class="col-sm-3 control-label">Minute Interval</label>
+                        <!-- Minutely Options -->
+                        <div class="form-group schedule-options" id="schedule_minutely_options" style="display:none;">
+                            <label for="schedule_interval" class="col-sm-3 control-label">Run Every</label>
                             <div class="col-sm-6">
-                                <input type="number" class="form-control" id="schedule_interval" name="schedule_interval" value="<?php echo isset($etl_config['schedule_interval']) ? htmlspecialchars($etl_config['schedule_interval'], ENT_QUOTES, 'UTF-8') : '5'; ?>" min="1">
-                                <p class="help-block">Run every X minutes.</p>
+                                <select class="form-control" id="schedule_interval" name="schedule_interval">
+                                    <?php $intervals = [1, 5, 10, 15, 20, 30, 45]; ?>
+                                    <?php foreach ($intervals as $interval): ?>
+                                        <option value="<?php echo $interval; ?>" <?php echo (isset($etl_config['schedule_interval']) && $etl_config['schedule_interval'] == $interval) ? 'selected' : ''; ?>>
+                                            <?php echo $interval; ?> minute(s)
+                                        </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+                        </div>
+
+                        <!-- Hourly Options -->
+                        <div class="form-group schedule-options" id="schedule_hourly_options" style="display:none;">
+                            <label for="schedule_hours" class="col-sm-3 control-label">Run On The Hour(s)</label>
+                            <div class="col-sm-6">
+                                <select class="form-control select2-multiple" id="schedule_hours" name="schedule_hours[]" multiple>
+                                    <?php for ($i = 0; $i < 24; $i++): ?>
+                                        <option value="<?php echo $i; ?>" <?php echo (isset($etl_config['schedule_hours']) && in_array($i, (array)$etl_config['schedule_hours'])) ? 'selected' : ''; ?>>
+                                            <?php echo str_pad($i, 2, '0', STR_PAD_LEFT) . ':00'; ?>
+                                        </option>
+                                    <?php endfor; ?>
+                                </select>
+                                <p class="help-block">Select one or more hours. The job will run once within each selected hour.</p>
+                            </div>
+                        </div>
+
+                        <!-- Daily Options -->
+                        <div class="form-group schedule-options" id="schedule_daily_options" style="display:none;">
+                            <label for="schedule_days" class="col-sm-3 control-label">Run On Day(s) of Month</label>
+                            <div class="col-sm-6">
+                                <select class="form-control select2-multiple" id="schedule_days" name="schedule_days[]" multiple>
+                                    <?php for ($i = 1; $i <= 31; $i++): ?>
+                                        <option value="<?php echo $i; ?>" <?php echo (isset($etl_config['schedule_days']) && in_array($i, (array)$etl_config['schedule_days'])) ? 'selected' : ''; ?>>
+                                            Day <?php echo $i; ?>
+                                        </option>
+                                    <?php endfor; ?>
+                                </select>
+                                <p class="help-block">Select one or more days of the month. The job will run at midnight on these days.</p>
                             </div>
                         </div>
 
@@ -118,18 +154,29 @@
     var etlConfig = <?php echo json_encode($etl_config); ?>;
 
     $(document).ready(function() {
-        function toggleScheduleInterval() {
-            if ($('#schedule_type').val() === 'minutely') {
-                $('#schedule_interval_group').show();
-            } else {
-                $('#schedule_interval_group').hide();
+        // Initialize select2 for the new multi-select boxes
+        $('.select2-multiple').select2({
+            placeholder: 'Click to select options'
+        });
+
+        function toggleScheduleOptions() {
+            // Hide all schedule option groups
+            $('.schedule-options').hide();
+
+            var selectedType = $('#schedule_type').val();
+            if (selectedType === 'minutely') {
+                $('#schedule_minutely_options').show();
+            } else if (selectedType === 'hourly') {
+                $('#schedule_hourly_options').show();
+            } else if (selectedType === 'daily') {
+                $('#schedule_daily_options').show();
             }
         }
 
-        $('#schedule_type').on('change', toggleScheduleInterval);
+        $('#schedule_type').on('change', toggleScheduleOptions);
 
         // Initial check on page load
-        toggleScheduleInterval();
+        toggleScheduleOptions();
     });
 </script>
 

--- a/cron.php
+++ b/cron.php
@@ -12,61 +12,71 @@ date_default_timezone_set('UTC');
 echo "Cron job started at " . date('Y-m-d H:i:s') . "\n";
 
 /**
- * Checks if a scheduled ETL job is due to run.
+ * Checks if a scheduled ETL job is due to run based on its specific configuration.
  *
  * @param array $etl_config The decoded etl_config from the database.
+ * @param DateTime $now The current time.
  * @return bool True if the job is due, false otherwise.
  */
-function isJobDue($etl_config) {
+function isJobDue($etl_config, DateTime $now) {
     $schedule_type = $etl_config['schedule_type'] ?? 'inactive';
     if ($schedule_type === 'inactive') {
         return false;
     }
 
-    $last_run_at_str = $etl_config['last_run_at'] ?? null;
-
-    // If it has never been run, it's due now.
-    if (!$last_run_at_str) {
-        return true;
+    $last_run_at = null;
+    if (isset($etl_config['last_run_at'])) {
+        try {
+            $last_run_at = new DateTime($etl_config['last_run_at']);
+        } catch (Exception $e) {
+            echo "Skipping job due to invalid last_run_at date format: " . $etl_config['last_run_at'] . "\n";
+            return false;
+        }
     }
 
-    try {
-        $last_run_at = new DateTime($last_run_at_str);
-        $now = new DateTime();
+    switch ($schedule_type) {
+        case 'minutely':
+            $interval = (int)($etl_config['schedule_interval'] ?? 5);
+            if (!$last_run_at) return true; // First run
+            $next_run_at = (clone $last_run_at)->add(new DateInterval("PT{$interval}M"));
+            return $now >= $next_run_at;
 
-        $next_run_at = clone $last_run_at;
+        case 'hourly':
+            $allowed_hours = $etl_config['schedule_hours'] ?? [];
+            if (empty($allowed_hours)) return false;
+            $current_hour = (int)$now->format('G'); // 0-23 format
+            if (!in_array($current_hour, $allowed_hours)) {
+                return false; // Not a scheduled hour
+            }
+            if (!$last_run_at) return true; // Never run before, and it's a valid hour
+            // Check if the last run was in a different hour. This prevents multiple runs in the same hour.
+            return $last_run_at->format('Y-m-d H') !== $now->format('Y-m-d H');
 
-        switch ($schedule_type) {
-            case 'minutely':
-                $interval_minutes = (int)($etl_config['schedule_interval'] ?? 5);
-                $next_run_at->add(new DateInterval('PT' . $interval_minutes . 'M'));
-                break;
-            case 'hourly':
-                $next_run_at->add(new DateInterval('PT1H'));
-                break;
-            case 'daily':
-                $next_run_at->add(new DateInterval('P1D'));
-                break;
-            case 'weekly':
-                $next_run_at->add(new DateInterval('P1W'));
-                break;
-            case 'monthly':
-                $next_run_at->add(new DateInterval('P1M'));
-                break;
-            default:
-                return false;
-        }
+        case 'daily':
+            $allowed_days = $etl_config['schedule_days'] ?? [];
+            if (empty($allowed_days)) return false;
+            $current_day = (int)$now->format('j'); // 1-31 format
+             if (!in_array($current_day, $allowed_days)) {
+                return false; // Not a scheduled day
+            }
+            // Check if time is past midnight (it always will be if cron runs after 00:00)
+            if (!$last_run_at) return true; // Never run before, and it's a valid day
+            // Check if the last run was on a different day. Prevents multiple runs on the same day.
+            return $last_run_at->format('Y-m-d') !== $now->format('Y-m-d');
 
-        return $now >= $next_run_at;
+        case 'weekly':
+            if (!$last_run_at) return true; // First run
+            $next_run_at = (clone $last_run_at)->add(new DateInterval('P1W'));
+            return $now >= $next_run_at;
 
-    } catch (Exception $e) {
-        // Log error if date parsing fails, and assume not due.
-        echo "Error checking schedule for a job: " . $e->getMessage() . "\n";
-        return false;
+        default:
+            return false;
     }
 }
 
-// Fetch all saved queries that might have an ETL configuration.
+// --- Main Execution Logic ---
+
+$now = new DateTime();
 $saved_queries = ORM::for_table('saved_queries')->where_not_null('etl_config')->find_many();
 
 echo "Found " . count($saved_queries) . " queries with ETL config.\n";
@@ -79,7 +89,7 @@ foreach ($saved_queries as $saved_query) {
         continue;
     }
 
-    if (isJobDue($etl_config)) {
+    if (isJobDue($etl_config, $now)) {
         echo "Query ID {$saved_query->id} ('{$saved_query->query_name}') is due. Starting ETL process.\n";
 
         $log = ORM::for_table('etl_logs')->create();
@@ -91,22 +101,23 @@ foreach ($saved_queries as $saved_query) {
 
         // Execute the refactored ETL job logic
         $result = ETL::executeEtlJob($saved_query);
+        $current_execution_time = date('Y-m-d H:i:s');
 
         // Update the log with the result
         if ($result['status'] === 'success' || $result['status'] === 'info') {
             $log->status = 'success';
             // Update the 'last_run_at' timestamp ONLY on successful execution
-            $etl_config['last_run_at'] = date('Y-m-d H:i:s');
+            $etl_config['last_run_at'] = $current_execution_time;
             $saved_query->etl_config = json_encode($etl_config);
             $saved_query->save();
-             echo "ETL for query ID {$saved_query->id} completed successfully.\n";
+            echo "ETL for query ID {$saved_query->id} completed successfully.\n";
         } else { // 'error'
             $log->status = 'failed';
             echo "ETL for query ID {$saved_query->id} failed: " . $result['message'] . "\n";
         }
 
         $log->message = $result['message'];
-        $log->ended_at = date('Y-m-d H:i:s');
+        $log->ended_at = $current_execution_time;
         $log->save();
 
         echo "Finished processing for query ID {$saved_query->id}.\n\n";
@@ -114,5 +125,4 @@ foreach ($saved_queries as $saved_query) {
 }
 
 echo "Cron job finished at " . date('Y-m-d H:i:s') . "\n";
-
 ?>


### PR DESCRIPTION
This commit enhances the ETL scheduling feature by providing more granular control over when jobs are executed.

Based on user feedback, the following changes have been implemented:
- **Minutely Schedules:** Users can now select from a predefined list of intervals (1, 5, 10, 15, 20, 30, 45 minutes).
- **Hourly Schedules:** Users can select multiple specific hours of the day (0-23) for a job to run. The job will run once within each selected hour.
- **Daily Schedules:** Users can select multiple specific days of the month (1-31) for a job to run. The job will execute at midnight on the selected days.
- **Monthly Option Removed:** The previous generic "Monthly" option has been removed in favor of the more specific "Daily" (on days of the month) option.
- **UI Updates:** The ETL configuration page has been updated with multi-select boxes and dropdowns to support these new options.
- **Cron Logic Overhaul:** The `cron.php` script has been significantly updated with more robust logic to correctly interpret these new, complex scheduling rules.