### PR TITLE
fix: Resolve JavaScript error on ETL page

### DIFF
--- a/app/views/etl.php
+++ b/app/views/etl.php
@@ -152,32 +152,6 @@
 <script>
     // Pass the PHP etl_config to JavaScript
     var etlConfig = <?php echo json_encode($etl_config); ?>;
-
-    $(document).ready(function() {
-        // Initialize select2 for the new multi-select boxes
-        $('.select2-multiple').select2({
-            placeholder: 'Click to select options'
-        });
-
-        function toggleScheduleOptions() {
-            // Hide all schedule option groups
-            $('.schedule-options').hide();
-
-            var selectedType = $('#schedule_type').val();
-            if (selectedType === 'minutely') {
-                $('#schedule_minutely_options').show();
-            } else if (selectedType === 'hourly') {
-                $('#schedule_hourly_options').show();
-            } else if (selectedType === 'daily') {
-                $('#schedule_daily_options').show();
-            }
-        }
-
-        $('#schedule_type').on('change', toggleScheduleOptions);
-
-        // Initial check on page load
-        toggleScheduleOptions();
-    });
 </script>
 
 <?php require_once 'includes/footer.php'; ?>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1239,6 +1239,38 @@ $(document).ready(function() {
             $('.key-column input[type="checkbox"]').prop('checked', false);
         }
     });
+
+    // ETL Page: Initialize select2 for scheduling options
+    if ($('#schedule_hours').length) {
+        $('#schedule_hours, #schedule_days').select2({
+            placeholder: 'Click to select options'
+        });
+    }
+
+    // ETL Page: Toggle visibility of detailed schedule options
+    function toggleScheduleOptions() {
+        if (!$('#schedule_type').length) {
+            return; // Don't run if not on ETL page
+        }
+        // Hide all schedule option groups
+        $('.schedule-options').hide();
+
+        var selectedType = $('#schedule_type').val();
+        if (selectedType === 'minutely') {
+            $('#schedule_minutely_options').show();
+        } else if (selectedType === 'hourly') {
+            $('#schedule_hourly_options').show();
+        } else if (selectedType === 'daily') {
+            $('#schedule_daily_options').show();
+        }
+    }
+
+    // Bind the event handler only if the element exists
+    if ($('#schedule_type').length) {
+        $('#schedule_type').on('change', toggleScheduleOptions);
+        // Trigger on page load to set initial state
+        toggleScheduleOptions();
+    }
 });
 
 function updateTableDropdown(dataSourceId, callback) {


### PR DESCRIPTION
This commit fixes a JavaScript error on the ETL configuration page caused by an inline script executing before the jQuery library was loaded.

The faulty logic has been moved from an inline `<script>` tag in `etl.php` to the global `custom.js` file. This ensures the correct script execution order and resolves the "Uncaught ReferenceError: $ is not defined".

As a result, the dynamic UI for selecting detailed scheduling options now functions as intended.