### PR TITLE
fix: Resolve fatal error in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -5,6 +5,7 @@ if (php_sapi_name() !== 'cli') {
 }
 
 require 'boot.php';
+require_once 'vendor/j4mie/idiorm/idiorm.php';
 
 // Set a default timezone if not set in php.ini
 date_default_timezone_set('UTC');


### PR DESCRIPTION
This commit fixes a "Class 'ORM' not found" fatal error that occurred when running the cron.php script from the command line. The issue was caused by the Idiorm ORM library not being autoloaded correctly in the CLI environment.

An explicit require_once statement has been added to cron.php to ensure the library is loaded, allowing the script to execute successfully.