### PR TITLE
fix: Resolve "Class ETL not found" fatal error in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -6,6 +6,7 @@ if (php_sapi_name() !== 'cli') {
 
 require 'boot.php';
 require_once 'vendor/j4mie/idiorm/idiorm.php';
+require_once 'app/controllers/ETL.php';
 
 // --- Database Configuration for Cron ---
 // The cron environment doesn't seem to pick up the DB config automatically.


### PR DESCRIPTION
This commit fixes a "Class 'ETL' not found" fatal error that occurred when running the cron.php script from the command line. This was happening because the application's autoloader was not functioning correctly in the CLI environment.

An explicit require_once statement has been added to cron.php to ensure the ETL controller class is loaded before it is used.