### PR TITLE
fix: Resolve "undefined function" fatal error in cron.php

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -7,6 +7,7 @@ if (php_sapi_name() !== 'cli') {
 require 'boot.php';
 require_once 'vendor/j4mie/idiorm/idiorm.php';
 require_once 'app/controllers/ETL.php';
+require_once 'func.php';
 
 // --- Database Configuration for Cron ---
 // The cron environment doesn't seem to pick up the DB config automatically.


### PR DESCRIPTION
This commit fixes a "Call to undefined function toggleEncryption()" fatal error that occurred when running the `cron.php` script.

This was happening because the `func.php` file, which contains helper functions for the application, was not being loaded correctly in the command-line environment. An explicit `require_once` statement has been added to `cron.php` to ensure these functions are loaded and available, resolving the error.