### PR TITLE
fix: Prevent ETL log table from resizing

### DIFF
--- a/app/views/etl_log.php
+++ b/app/views/etl_log.php
@@ -8,7 +8,7 @@
                     <h3 class="panel-title"><i class="<?php echo $icon; ?>"></i> <?php echo $title; ?></h3>
                 </div>
                 <div class="panel-body">
-                    <table class="table table-striped table-bordered">
+                    <table id="etl_log_table" class="table table-striped table-bordered">
                         <thead>
                             <tr>
                                 <th>Query Name</th>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -8,7 +8,8 @@ $('.sidebar-nav a[href$="' + lastSegment + '"]').parents('li').addClass('activel
 
 // style tables
 if ($('table tr').length) {
-    $('.page-content table').not('table.nodatatable').dataTable({
+    // General datatable initialization with horizontal scroll
+    $('.page-content table').not('table.nodatatable, #etl_log_table').dataTable({
         sPaginationType: "full_numbers",
         bAutoWidth: false,
         autoWidth: false,
@@ -16,6 +17,18 @@ if ($('table tr').length) {
         iDisplayLength: 10,
         scrollX: 400
     });
+
+    // Specific initialization for ETL Log table without horizontal scroll
+    if ($('#etl_log_table').length) {
+        $('#etl_log_table').dataTable({
+            sPaginationType: "full_numbers",
+            bAutoWidth: false,
+            autoWidth: false,
+            bLengthChange: true,
+            iDisplayLength: 10
+            // No scrollX here
+        });
+    }
 }
 
 // replace selects with select2 - BEWARE: This global initializer might be problematic for hidden templates.


### PR DESCRIPTION
This commit fixes an issue where the ETL log table would initially appear wide and then resize to a narrow, scrollable layout. This was caused by a global DataTables initializer with a "scrollX" property.

The fix involves two parts:
1.  A unique ID (`etl_log_table`) is added to the table in the view.
2.  The global DataTables initializer in `custom.js` is updated to exclude this new ID.
3.  A new, specific DataTables initializer is added for `#etl_log_table` that omits the `scrollX` property.

This allows the table to correctly fill its wide container while preserving all sorting and pagination functionality.