### PR TITLE
fix: Correctly load VQB when editing from results page

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -748,13 +748,19 @@ $('body').on('click', '#btnEditExecutedQuery', function() {
     var executedQueryId = $('#executed_query_id').val(); // Might be empty if not a saved query
     var executedQueryName = $('#executed_query_name').val(); // Might be empty
     var wasSavedVisual = $('#executed_query_was_saved_visual').val() === 'true';
+    var dataSourceId = $('#executed_query_source_connection_id').val(); // Get the data source ID
+
+    if (!dataSourceId) {
+        $.jGrowl('Error: Could not determine the data source for this query.', { header: 'Error', theme: 'error' });
+        return;
+    }
 
     if (visualParamsJsonString && visualParamsJsonString !== '{}' && visualParamsJsonString !== '[]') {
         try {
             var parsedParams = JSON.parse(visualParamsJsonString);
             // If it was a saved visual query, its ID and name are used.
             // Otherwise, queryId and queryName will be empty, VQB opens for a new/adhoc query state.
-            openVisualQueryBuilderModal(parsedParams, executedQueryId, executedQueryName, wasSavedVisual);
+            openVisualQueryBuilderModal(parsedParams, executedQueryId, executedQueryName, wasSavedVisual, dataSourceId);
         } catch (e) {
             console.error("Error parsing #current_visual_params for editing:", e);
             $.jGrowl('Could not parse visual parameters to edit this query.', { header: 'Error' });


### PR DESCRIPTION
This commit fixes a bug where the Visual Query Builder (VQB) would fail to load table and column fields when editing a query from the results page.

The click handler for the "Edit Executed Query" button was not passing the query's data source ID to the VQB modal. The handler has been updated to read the data source ID from a hidden input on the page and pass it correctly, ensuring the VQB initializes with the proper context.