### PR TITLE
feat: Add PostgreSQL support for data sources and ETL destinations

### DIFF
--- a/app/controllers/DataSources.php
+++ b/app/controllers/DataSources.php
@@ -27,6 +27,7 @@ class DataSources
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $source = ORM::for_table('data_sources')->create();
             $source->source_name = $_POST['source_name'];
+            $source->db_type = $_POST['db_type'];
             $source->db_host = $_POST['db_host'];
             $source->db_port = $_POST['db_port'];
             $source->db_name = $_POST['db_name'];

--- a/app/controllers/Destinations.php
+++ b/app/controllers/Destinations.php
@@ -27,6 +27,7 @@ class Destinations
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $destination = ORM::for_table('destination_databases')->create();
             $destination->connection_name = $_POST['connection_name'];
+            $destination->db_type = $_POST['db_type'];
             $destination->db_host = $_POST['db_host'];
             $destination->db_port = $_POST['db_port'];
             $destination->db_name = $_POST['db_name'];

--- a/app/controllers/ajax.php
+++ b/app/controllers/ajax.php
@@ -32,13 +32,12 @@ class Ajax
                     $password = toggleEncryption($source->db_password);
 
                     // Create a temporary connection to the data source
-                    ORM::configure('mysql:host=' . $source->db_host . ';dbname=' . $source->db_name, null, 'temp_connection');
+                    ORM::configure(get_dsn($source), null, 'temp_connection');
                     ORM::configure('username', $source->db_user, 'temp_connection');
                     ORM::configure('password', $password, 'temp_connection');
 
                     $db = ORM::get_db('temp_connection');
-                    $stmt = $db->query('SHOW TABLES');
-                    $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+                    $tables = get_tables($db, $source->db_type);
 
                     $response['status'] = 'success';
                     $response['message'] = 'Tables retrieved successfully.';
@@ -714,12 +713,11 @@ class Ajax
             }
 
             $decrypted_password = toggleEncryption($destination_db->db_password);
-            $dsn = "mysql:host={$destination_db->db_host};port={$destination_db->db_port};dbname={$destination_db->db_name};charset=utf8";
+            $dsn = get_dsn($destination_db);
             $pdo = new PDO($dsn, $destination_db->db_user, $decrypted_password);
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-            $stmt = $pdo->query("SHOW TABLES");
-            $tables = $stmt->fetchAll(PDO::FETCH_COLUMN);
+            $tables = get_tables($pdo, $destination_db->db_type);
 
             echo json_encode(array('status' => 'success', 'tables' => $tables));
 
@@ -755,7 +753,7 @@ class Ajax
             }
 
             $source_decrypted_password = toggleEncryption($source_db_details->db_password);
-            $source_dsn = "mysql:host={$source_db_details->db_host};port={$source_db_details->db_port};dbname={$source_db_details->db_name};charset=utf8";
+            $source_dsn = get_dsn($source_db_details);
             $source_pdo = new PDO($source_dsn, $source_db_details->db_user, $source_decrypted_password);
             $source_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
@@ -774,7 +772,7 @@ class Ajax
                 throw new Exception("Destination database configuration not found.");
             }
             $decrypted_password = toggleEncryption($destination_db_details->db_password);
-            $dsn = "mysql:host={$destination_db_details->db_host};port={$destination_db_details->db_port};dbname={$destination_db_details->db_name};charset=utf8";
+            $dsn = get_dsn($destination_db_details);
             $dest_pdo = new PDO($dsn, $destination_db_details->db_user, $decrypted_password);
             $dest_pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 

--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -22,7 +22,7 @@ class Table
                 try {
                     $password = toggleEncryption($source->db_password);
 
-                    ORM::configure('mysql:host=' . $source->db_host . ';dbname=' . $source->db_name, null, $connection_name);
+                    ORM::configure(get_dsn($source), null, $connection_name);
                     ORM::configure('username', $source->db_user, $connection_name);
                     ORM::configure('password', $password, $connection_name);
                     ORM::configure('logging', true, $connection_name);
@@ -43,11 +43,14 @@ class Table
         $connection_name = self::get_data_source_connection_name();
         $db = ORM::get_db($connection_name);
         $table = Flight::get('lastSegment',$name);
+
+        // Get data source type
+        $source = ORM::for_table('data_sources')->find_one($_SESSION['selected_data_source']);
+        $db_type = $source ? $source->db_type : 'mysql'; // Default to mysql if source not found
     
         try {
             // Get table structure
-            $stmt = $db->query("DESCRIBE `$table`");
-            $table_fields_data = $stmt->fetchAll(PDO::FETCH_ASSOC); // Renamed to avoid conflict with $fields later
+            $table_fields_data = get_table_columns($db, $db_type, $table);
             // Pass the table name to getOptions to generate qualified field names
             $fieldOptions = getOptions(array_column($table_fields_data, 'Field'), false, $table);
         } catch (PDOException $e) {
@@ -71,20 +74,25 @@ class Table
         // Checks whether or not user is logged in
         self::checkLogin();
 
-        // enable query profiling
-        $db->query('SET profiling = 1;');
+        $exec_time_row = [[null, 'N/A']]; // Default value
+        if ($db_type === 'mysql') {
+            // enable query profiling
+            $db->query('SET profiling = 1;');
 
-        // get specified table data as array
-        $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
-        $the_query = ORM::get_last_query($connection_name);
-        //pretty_print($records);
+            // get specified table data as array
+            $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
+            $the_query = ORM::get_last_query($connection_name);
 
-        // find out time above query was ran for
-        $exec_time_result = $db->query(
-           'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
-        );
-
-        $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
+            // find out time above query was ran for
+            $exec_time_result = $db->query(
+               'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
+            );
+            $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
+        } else {
+            // For other DBs, just get the data without profiling
+            $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
+            $the_query = ORM::get_last_query($connection_name);
+        }
 
         // $fields_for_session is already populated from $table_fields_data earlier
         // No need for the second DESCRIBE query for $columns or re-populating $fields.
@@ -114,12 +122,8 @@ class Table
         $_db = Flight::get('db');
         $tablesOptionsHtmlForView = '<option value="">Error loading tables (Controller Default)</option>'; // Default
         try {
-            $allTablesStmt = $_db->query('SHOW TABLES');
-            $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
-            $tableNamesForOptions = [];
-            foreach ($allTablesResult as $row) {
-                $tableNamesForOptions[] = $row[0];
-            }
+            $source = ORM::for_table('data_sources')->find_one($_SESSION['selected_data_source']);
+            $tableNamesForOptions = get_tables($_db, $source->db_type);
             $currentTablesOptions = getOptions($tableNamesForOptions, true); // true for "Choose Table"
             if (!empty(trim($currentTablesOptions)) && strpos($currentTablesOptions, '<option') !== false) {
                 $tablesOptionsHtmlForView = $currentTablesOptions;
@@ -169,6 +173,10 @@ class Table
         $connection_name = self::get_data_source_connection_name($source_connection_id);
         $db = ORM::get_db($connection_name);
 
+        // Get data source type
+        $source = ORM::for_table('data_sources')->find_one($source_connection_id);
+        $db_type = $source ? $source->db_type : 'mysql';
+
         $tableName = null;
         $fields = [];
         try {
@@ -179,8 +187,7 @@ class Table
 
             if ($tableName) {
                 // Get table columns
-                $stmt = $db->query("DESCRIBE `$tableName`");
-                $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                $columns = get_table_columns($db, $db_type, $tableName);
                 $fields = array_column($columns, 'Field');
             }
         } catch (PDOException $e) {
@@ -208,9 +215,12 @@ class Table
             $printArray = pretty_print($_POST, false, true);
         }
 
+        // Get data source type
+        $source = ORM::for_table('data_sources')->find_one($_SESSION['selected_data_source']);
+        $db_type = $source ? $source->db_type : 'mysql';
+
         // table columns
-        $stmt = $db->query("DESCRIBE " . Flight::get('lastSegment'));
-        $columns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $columns = get_table_columns($db, $db_type, Flight::get('lastSegment'));
         //pretty_print($columns);
 
         $fields = array();
@@ -231,7 +241,7 @@ class Table
         else {
             // Use $primaryTableName which is Flight::get('lastSegment') in this context
             $primaryTableName = Flight::get('lastSegment');
-            $query = self::generateSqlFromVisualParams($_POST, $primaryTableName);
+            $query = self::generateSqlFromVisualParams($_POST, $primaryTableName, $db_type);
 
             // Collect visual parameters if this was a visual query build
             // Note: $_POST is passed directly to generateSqlFromVisualParams,
@@ -286,7 +296,7 @@ class Table
 
     }
 
-    public static function generateSqlFromVisualParams(array $params, string $primaryTableName): string
+    public static function generateSqlFromVisualParams(array $params, string $primaryTableName, string $db_type): string
     {
         $select_parts = [];
         $query = '';
@@ -324,26 +334,21 @@ class Table
                 }
 
                 $field_parts = explode('.', $field_name, 2);
-                $quoted_field_name = $field_name;
-                if (count($field_parts) == 2) {
-                    $quoted_field_name = "`" . str_replace("`", "``", $field_parts[0]) . "`.`" . str_replace("`", "``", $field_parts[1]) . "`";
-                } else {
-                    $quoted_field_name = "`" . str_replace("`", "``", $field_name) . "`";
-                }
+                $quoted_field_name = quote_identifier($field_name, $db_type);
 
                 $agg_string = $func . '(' . $quoted_field_name . ')';
 
                 if (!empty($alias)) {
                     $alias = preg_replace('/[^a-zA-Z0-9_]/', '', $alias);
                     if (!empty($alias)) {
-                        $agg_string .= ' AS `' . $alias . '`';
+                        $agg_string .= ' AS ' . quote_identifier($alias, $db_type);
                     } else {
                         $default_alias = strtolower($func . '_' . preg_replace('/[^a-zA-Z0-9_]/', '', $field_parts[1] ?? $field_name));
-                        $agg_string .= ' AS `' . $default_alias . '`';
+                        $agg_string .= ' AS ' . quote_identifier($default_alias, $db_type);
                     }
                 } else {
                     $default_alias = strtolower($func . '_' . preg_replace('/[^a-zA-Z0-9_]/', '', $field_parts[1] ?? $field_name));
-                    $agg_string .= ' AS `' . $default_alias . '`';
+                    $agg_string .= ' AS ' . quote_identifier($default_alias, $db_type);
                 }
                 $select_parts[] = $agg_string;
             }
@@ -355,7 +360,7 @@ class Table
             $query = 'SELECT ' . implode(', ', $select_parts);
         }
 
-        $query .= ' FROM `' . str_replace("`", "``", $primaryTableName) . '`';
+        $query .= ' FROM ' . quote_identifier($primaryTableName, $db_type);
 
         // Joins
         if (!empty($params['jointype']) && is_array($params['jointype'])) {
@@ -364,20 +369,14 @@ class Table
                     continue;
                 }
                 $query .= ' ' . $value . ' '; // $value is jointype
-                $query .= '`' . str_replace('`', '``', $params['jointable'][$key]) . '`';
+                $query .= quote_identifier($params['jointable'][$key], $db_type);
 
                 if (!empty($params['joinfieldp'][$key]) && !empty($params['joinfield'][$key])) {
                     $primary_join_field = $params['joinfieldp'][$key];
-                    if (strpos($primary_join_field, '.') !== false) {
-                        list($pt_table, $pt_col) = explode('.', $primary_join_field, 2);
-                        $primary_join_field_sql = '`' . str_replace('`', '``', $pt_table) . '`.`' . str_replace('`', '``', $pt_col) . '`';
-                    } else {
-                        $primary_join_field_sql = '`' . str_replace('`', '``', $primaryTableName) . '`.`' . str_replace('`', '``', $primary_join_field) . '`';
-                    }
+                    $primary_join_field_sql = quote_identifier($primary_join_field, $db_type);
 
                     $secondary_join_field = $params['joinfield'][$key];
-                    // Note: joinfield from VQB is usually not qualified, it's a field from jointable[$key]
-                     $secondary_join_field_sql = '`' . str_replace('`', '``', $params['jointable'][$key]) . '`.`' . str_replace('`', '``', $secondary_join_field) . '`';
+                    $secondary_join_field_sql = quote_identifier($params['jointable'][$key] . '.' . $secondary_join_field, $db_type);
 
                     $query .= ' ON ' . $primary_join_field_sql . ' = ' . $secondary_join_field_sql;
                 }
@@ -391,12 +390,6 @@ class Table
                 if (!empty($params['fvalue'][$key])) { // Ensure there's a value for the condition
                     $condition = $value . $params['fvalue'][$key]; // $value is field name, fvalue has operator + value
                     if (isset($params['ftype'][$key]) && $key > 0 && count($where_conditions) > 0) { // ftype is for condition linking (AND/OR)
-                         // ftype is actually for the *next* condition, so it should be used for $params['ftype'][$key] to link to previous
-                         // This part of original logic might be slightly off. For safety, let's assume ftype[$key] links the current to previous.
-                         // A more robust way is to ensure ftype array is correctly aligned or build conditions step-by-step.
-                         // The original code uses $params['ftype'][$key + 1] which is problematic if $key is the last one.
-                         // Let's assume $params['ftype'][$key] links the condition at $key to the one at $key-1.
-                         // The first condition won't have a preceding ftype.
                         if (isset($params['ftype'][$key]) && !empty($where_conditions) ) { // Check if ftype for current index exists
                             $where_conditions[] = ($params['ftype'][$key] ?? 'AND') . ' ' . $condition;
                         } else {
@@ -418,15 +411,7 @@ class Table
                         }
 
                         // Properly quote the field name ($value is fname)
-                        $quoted_field_name = $value;
-                        if (strpos($value, '.') !== false) {
-                            list($table_part, $column_part) = explode('.', $value, 2);
-                            $quoted_field_name = '`' . str_replace('`', '``', $table_part) . '`.`' . str_replace('`', '``', $column_part) . '`';
-                        } else {
-                            // If no table part, assume it's a column of the primary table or an alias that's already correctly named.
-                            // VQB usually provides qualified names (table.column) for fname.
-                            $quoted_field_name = '`' . str_replace('`', '``', $value) . '`';
-                        }
+                        $quoted_field_name = quote_identifier($value, $db_type);
 
                         // Append quoted field name, a space, and then the fvalue (which should contain operator + value)
                         $query .= $quoted_field_name . ' ' . $params['fvalue'][$key];
@@ -439,7 +424,9 @@ class Table
         // GROUP BY fields
         if (!empty($params['groupfields']) && is_array($params['groupfields']) && count(array_filter($params['groupfields'])) > 0) {
             $query .= ' GROUP BY ';
-            $query .= implode(', ', array_filter($params['groupfields']));
+            $query .= implode(', ', array_map(function($field) use ($db_type) {
+                return quote_identifier($field, $db_type);
+            }, array_filter($params['groupfields'])));
         }
 
         // HAVING clause
@@ -452,16 +439,7 @@ class Table
                         $hcondition_string .= ' ' . ($params['htype'][$key] ?? 'AND') . ' ';
                     }
 
-                    if (strpos($hfname_val, '.') === false) {
-                        $hcondition_string .= '`' . str_replace("`", "``", $hfname_val) . '`';
-                    } else {
-                        $hfield_parts = explode('.', $hfname_val, 2);
-                        if (count($hfield_parts) == 2) {
-                            $hcondition_string .= "`" . str_replace("`", "``", $hfield_parts[0]) . "`.`" . str_replace("`", "``", $hfield_parts[1]) . "`";
-                        } else {
-                            $hcondition_string .= "`" . str_replace("`", "``", $hfname_val) . "`";
-                        }
-                    }
+                    $hcondition_string .= quote_identifier($hfname_val, $db_type);
                     $hcondition_string .= ' ' . $params['hfvalue'][$key];
                     $having_conditions_parts[] = $hcondition_string;
                 }
@@ -474,17 +452,24 @@ class Table
         // ORDER BY fields
         if (!empty($params['orderfields']) && is_array($params['orderfields']) && count(array_filter($params['orderfields'])) > 0) {
             $query .= ' ORDER BY ';
-            $query .= implode(', ', array_filter($params['orderfields']));
+            $query .= implode(', ', array_map(function($field) use ($db_type) {
+                return quote_identifier($field, $db_type);
+            }, array_filter($params['orderfields'])));
             if (isset($params['chkDescending']) && ($params['chkDescending'] === 'on' || $params['chkDescending'] === true)) {
                 $query .= ' DESC ';
             }
         }
 
         // LIMIT clause
-        if (!empty($params['limitStart']) && is_numeric($params['limitStart'])) {
+        if ($db_type === 'mysql' && !empty($params['limitStart']) && is_numeric($params['limitStart'])) {
             $query .= ' LIMIT ' . (int)$params['limitStart'];
             if (!empty($params['limitNumRows']) && is_numeric($params['limitNumRows'])) {
                 $query .= ', ' . (int)$params['limitNumRows'];
+            }
+        } elseif ($db_type === 'postgresql' && !empty($params['limitNumRows']) && is_numeric($params['limitNumRows'])) {
+            $query .= ' LIMIT ' . (int)$params['limitNumRows'];
+            if (!empty($params['limitStart']) && is_numeric($params['limitStart'])) {
+                $query .= ' OFFSET ' . (int)$params['limitStart'];
             }
         }
 
@@ -504,16 +489,15 @@ class Table
         $exec_time_row = array();
         $records = '';
 
+        // Get data source type
+        $source = ORM::for_table('data_sources')->find_one($_SESSION['selected_data_source']);
+        $db_type = $source ? $source->db_type : 'mysql';
+
         // Ensure tablesOptions is available for the view context by generating it directly
         $_db = $db;
         $tablesOptionsHtmlForView = '<option value="">Error loading tables (Controller Default)</option>'; // Default
         try {
-            $allTablesStmt = $_db->query('SHOW TABLES');
-            $allTablesResult = $allTablesStmt->fetchAll(PDO::FETCH_NUM);
-            $tableNamesForOptions = [];
-            foreach ($allTablesResult as $row) {
-                $tableNamesForOptions[] = $row[0];
-            }
+            $tableNamesForOptions = get_tables($_db, $db_type);
             $currentTablesOptions = getOptions($tableNamesForOptions, true); // true for "Choose Table"
             if (!empty(trim($currentTablesOptions)) && strpos($currentTablesOptions, '<option') !== false) {
                 $tablesOptionsHtmlForView = $currentTablesOptions;
@@ -526,17 +510,24 @@ class Table
         }
 
         try {
-            // turn on query profiling
-            $db->query('SET profiling = 1;');
+            if ($db_type === 'mysql') {
+                // turn on query profiling
+                $db->query('SET profiling = 1;');
+            }
 
             $stmt = $db->query($query);
 
-            // find out time above query was ran for
-            $exec_time_result = $db->query(
-               'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
-            );
+            if ($db_type === 'mysql') {
+                // find out time above query was ran for
+                $exec_time_result = $db->query(
+                   'SELECT query_id, SUM(duration) FROM information_schema.profiling GROUP BY query_id ORDER BY query_id DESC LIMIT 1;'
+                );
 
-            $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
+                $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
+            } else {
+                $exec_time_row = [[null, 'N/A']];
+            }
+
 
             // run query and fetch array
             $data = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/app/views/datasources.php
+++ b/app/views/datasources.php
@@ -12,6 +12,13 @@
                             <input type="text" class="form-control" id="source_name" name="source_name" placeholder="e.g., Production OLTP" required>
                         </div>
                         <div class="form-group">
+                            <label for="db_type">Database Type</label>
+                            <select class="form-control" id="db_type" name="db_type" required>
+                                <option value="mysql">MySQL</option>
+                                <option value="postgresql">PostgreSQL</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label for="db_host">Host</label>
                             <input type="text" class="form-control" id="db_host" name="db_host" placeholder="e.g., 127.0.0.1" required>
                         </div>
@@ -44,6 +51,7 @@
                         <thead>
                             <tr>
                                 <th>Source Name</th>
+                                <th>Type</th>
                                 <th>Host</th>
                                 <th>Database</th>
                                 <th>User</th>
@@ -55,6 +63,7 @@
                                 <?php foreach ($sources as $source): ?>
                                     <tr>
                                         <td><?php echo htmlspecialchars($source->source_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($source->db_type, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($source->db_host, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($source->db_name, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($source->db_user, ENT_QUOTES, 'UTF-8'); ?></td>

--- a/app/views/destinations.php
+++ b/app/views/destinations.php
@@ -12,6 +12,13 @@
                             <input type="text" class="form-control" id="connection_name" name="connection_name" placeholder="e.g., Production DWH" required>
                         </div>
                         <div class="form-group">
+                            <label for="db_type">Database Type</label>
+                            <select class="form-control" id="db_type" name="db_type" required>
+                                <option value="mysql">MySQL</option>
+                                <option value="postgresql">PostgreSQL</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
                             <label for="db_host">Host</label>
                             <input type="text" class="form-control" id="db_host" name="db_host" placeholder="e.g., 127.0.0.1" required>
                         </div>
@@ -44,6 +51,7 @@
                         <thead>
                             <tr>
                                 <th>Connection Name</th>
+                                <th>Type</th>
                                 <th>Host</th>
                                 <th>Database</th>
                                 <th>User</th>
@@ -55,6 +63,7 @@
                                 <?php foreach ($destinations as $dest): ?>
                                     <tr>
                                         <td><?php echo htmlspecialchars($dest->connection_name, ENT_QUOTES, 'UTF-8'); ?></td>
+                                        <td><?php echo htmlspecialchars($dest->db_type, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($dest->db_host, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($dest->db_name, ENT_QUOTES, 'UTF-8'); ?></td>
                                         <td><?php echo htmlspecialchars($dest->db_user, ENT_QUOTES, 'UTF-8'); ?></td>

--- a/destination_databases.sql
+++ b/destination_databases.sql
@@ -1,6 +1,6 @@
-CREATE TABLE `data_sources` (
+CREATE TABLE `destination_databases` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `source_name` varchar(255) NOT NULL,
+  `connection_name` varchar(255) NOT NULL,
   `db_type` varchar(255) NOT NULL,
   `db_host` varchar(255) NOT NULL,
   `db_port` varchar(255) DEFAULT NULL,

--- a/func.php
+++ b/func.php
@@ -446,3 +446,61 @@ function timeoutLogout($minutes)
     // update last activity time stamp with each request
     $_SESSION['LAST_ACTIVITY'] = time();
 }
+
+function get_dsn($source) {
+    $portString = '';
+    if (!empty($source->db_port)) {
+        $portString = ";port={$source->db_port}";
+    }
+
+    if ($source->db_type === 'postgresql') {
+        return "pgsql:host={$source->db_host}{$portString};dbname={$source->db_name}";
+    }
+    // Default to mysql
+    return "mysql:host={$source->db_host}{$portString};dbname={$source->db_name}";
+}
+
+function get_tables($db, $db_type) {
+    if ($db_type === 'postgresql') {
+        $stmt = $db->query("SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'");
+        return $stmt->fetchAll(PDO::FETCH_COLUMN);
+    }
+    // Default to mysql
+    $stmt = $db->query('SHOW TABLES');
+    return $stmt->fetchAll(PDO::FETCH_COLUMN);
+}
+
+function get_table_columns($db, $db_type, $table_name) {
+    if ($db_type === 'postgresql') {
+        // For PostgreSQL, we query the information_schema. The column names are returned as "Field" and "Type" for compatibility with the existing code that processes MySQL's DESCRIBE output.
+        $stmt = $db->prepare("SELECT column_name AS \"Field\", data_type AS \"Type\", is_nullable AS \"Null\", column_default AS \"Default\" FROM information_schema.columns WHERE table_name = ?");
+        $stmt->execute([$table_name]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    // Default to mysql
+    $stmt = $db->query("DESCRIBE `$table_name`");
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function quote_identifier($identifier, $db_type) {
+    if (strpos($identifier, '.') !== false) {
+        $parts = explode('.', $identifier);
+        $quoted_parts = [];
+        foreach ($parts as $part) {
+            if ($db_type === 'postgresql') {
+                $quoted_parts[] = '"' . str_replace('"', '""', $part) . '"';
+            } else {
+                $quoted_parts[] = '`' . str_replace('`', '``', $part) . '`';
+            }
+        }
+        return implode('.', $quoted_parts);
+    }
+
+    if ($db_type === 'postgresql') {
+        return '"' . str_replace('"', '""', $identifier) . '"';
+    }
+
+    // Default to mysql
+    return '`' . str_replace('`', '``', $identifier) . '`';
+}

--- a/index.php
+++ b/index.php
@@ -107,7 +107,7 @@ if (isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source'
             $password = toggleEncryption($source->db_password);
 
             // Configure a temporary, distinct connection for fetching tables
-            ORM::configure('mysql:host=' . $source->db_host . ';dbname=' . $source->db_name, null, $connection_name);
+            ORM::configure(get_dsn($source), null, $connection_name);
             ORM::configure('username', $source->db_user, $connection_name);
             ORM::configure('password', $password, $connection_name);
             ORM::configure('logging', true, $connection_name);
@@ -115,8 +115,7 @@ if (isset($_SESSION['selected_data_source']) && $_SESSION['selected_data_source'
             $source_db = ORM::get_db($connection_name);
 
             // Fetch tables from the selected data source
-            $stmt = $source_db->query("SHOW TABLES");
-            $data = $stmt->fetchAll(PDO::FETCH_NUM);
+            $data = get_tables($source_db, $source->db_type);
             $data = arrayFlatten($data);
 
         } catch (PDOException $e) {


### PR DESCRIPTION
This change adds support for using PostgreSQL databases as data sources for querying and as destinations for ETL processes.

Key changes include:
- Adding a `db_type` column to the `data_sources` and `destination_databases` tables to store the database type (MySQL or PostgreSQL).
- Updating the UI to allow users to select the database type when creating a new data source or destination.
- Creating a set of database abstraction helper functions (`get_dsn`, `get_tables`, `get_table_columns`, `quote_identifier`) in `func.php` to handle database-specific SQL syntax.
- Refactoring `table.php` and other files to use these helper functions, replacing hardcoded MySQL-specific queries (`DESCRIBE`, `SHOW TABLES`, backticks) with database-agnostic calls.
- Updating the visual query builder to generate SQL compatible with both MySQL and PostgreSQL, including correct handling of `LIMIT`/`OFFSET` clauses and identifier quoting.