### PR TITLE
Add a 100-row limit to queries run from the UI

### DIFF
--- a/app/controllers/table.php
+++ b/app/controllers/table.php
@@ -74,13 +74,15 @@ class Table
         // Checks whether or not user is logged in
         self::checkLogin();
 
+        $_SESSION['unlimitedQuery'] = "SELECT * FROM `$table`";
+
         $exec_time_row = [[null, 'N/A']]; // Default value
         if ($db_type === 'mysql') {
             // enable query profiling
             $db->query('SET profiling = 1;');
 
             // get specified table data as array
-            $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
+            $records = ORM::for_table($table, $connection_name)->limit(100)->find_array();
             $the_query = ORM::get_last_query($connection_name);
 
             // find out time above query was ran for
@@ -90,7 +92,7 @@ class Table
             $exec_time_row = $exec_time_result->fetchAll(PDO::FETCH_NUM);
         } else {
             // For other DBs, just get the data without profiling
-            $records = ORM::for_table(Flight::get('lastSegment'), $connection_name)->find_array();
+            $records = ORM::for_table($table, $connection_name)->limit(100)->find_array();
             $the_query = ORM::get_last_query($connection_name);
         }
 


### PR DESCRIPTION
This change adds a 100-row limit to queries that are run from the web interface, either from the saved query list, the custom query page, or when viewing a table directly. This is to prevent the server from crashing when a query returns a very large number of rows.

The limit is not applied when the query results are exported to CSV or Excel, or when the query is run as part of an ETL job. To achieve this, the original, unlimited query is stored in the session and used for exports.