### PR TITLE
Fix: SFTP fatal error due to class not found

### DIFF
--- a/app/controllers/ETL.php
+++ b/app/controllers/ETL.php
@@ -209,6 +209,9 @@ class ETL
         try {
             // Load phpseclib classes
             require_once 'vendor/autoload.php';
+            if (file_exists('vendor/phpseclib/phpseclib/phpseclib/bootstrap.php')) {
+                require_once 'vendor/phpseclib/phpseclib/phpseclib/bootstrap.php';
+            }
             
             $csv_separator = $etl_config['csv_separator'] ?? ',';
             


### PR DESCRIPTION
- Added a `require_once` for the phpseclib bootstrap file in `app/controllers/ETL.php`.
- This ensures that the `phpseclib3\Net\SFTP` class is loaded correctly, resolving the fatal error that occurred when running an SFTP ETL job.