### PR TITLE
Fix: Correct Select2 initialization in VQB modal

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -587,7 +587,11 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
 
                 $clone.find('select').each(function () {
                     if ($(this).data('select2')) $(this).select2('destroy');
-                    $(this).select2({ placeholder: 'Choose', allowClear: true });
+                    $(this).select2({
+                        placeholder: 'Choose',
+                        allowClear: true,
+                        dropdownParent: $(this).closest('.modal')
+                    });
                 });
                 $clone.show();
 
@@ -633,8 +637,14 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
                                 $ftypeSelect.val(visualParamsObj.ftype[idx]);
                             }
                             $('#btnAddWhere').after($c);
-                            $fnameSelect.select2({ placeholder: 'Choose Field', allowClear: true });
-                            $ftypeSelect.select2();
+                            $fnameSelect.select2({
+                                placeholder: 'Choose Field',
+                                allowClear: true,
+                                dropdownParent: $fnameSelect.closest('.modal')
+                            });
+                            $ftypeSelect.select2({
+                                dropdownParent: $ftypeSelect.closest('.modal')
+                            });
                             $fnameSelect.trigger('change');
                             $ftypeSelect.trigger('change');
                         }
@@ -655,8 +665,14 @@ function openVisualQueryBuilderModal(visualParamsObj, queryId, queryName, isEdit
                             $aggFuncSelect.val(visualParamsObj.agg_func[idx]);
                             $aggClone.find('.agg_alias').val(visualParamsObj.agg_alias[idx] || '');
                             $aggContainer.append($aggClone);
-                            $aggFieldSelect.select2({ placeholder: 'Select Field', allowClear: true });
-                            $aggFuncSelect.select2();
+                            $aggFieldSelect.select2({
+                                placeholder: 'Select Field',
+                                allowClear: true,
+                                dropdownParent: $aggFieldSelect.closest('.modal')
+                            });
+                            $aggFuncSelect.select2({
+                                dropdownParent: $aggFuncSelect.closest('.modal')
+                            });
                             $aggFieldSelect.trigger('change');
                             $aggFuncSelect.trigger('change');
                         }


### PR DESCRIPTION
The search functionality for Select2 dropdowns was not working inside the Visual Query Builder (VQB) modal. This was because the search input was read-only.

This is a common issue when using Select2 inside Bootstrap modals. The modal traps focus, and the Select2 dropdown, which is appended to the body by default, cannot receive focus.

The solution is to set the `dropdownParent` option on Select2 to the modal element. This ensures the dropdown is part of the modal's DOM and can receive focus.

This commit applies this fix to all Select2 instances within the VQB modal, including when adding new elements and when loading existing query data. It also updates the global Select2 initializer to be aware of modals.