### PR TITLE
Fix: Pre-populate VQB update modal with query name and connection

### DIFF
--- a/app/views/visual_query_builder.php
+++ b/app/views/visual_query_builder.php
@@ -39,7 +39,7 @@ $isEditMode = !empty($queryId);
                 </div>
                 
                 <div class="panel-body">
-                    <form action="<?php echo Flight::get('base'); ?>/vqb<?php echo $currentTable ? '/' . $currentTable : ''; ?>" method="post" class="form-horizontal" role="form" id="vqb-form">
+                    <form action="<?php echo Flight::get('base'); ?>/vqb<?php echo $currentTable ? '/' . $currentTable : ''; ?>" method="post" class="form-horizontal" role="form" id="vqb-form" data-source-id="<?php echo htmlspecialchars($dataSourceId); ?>" data-query-name="<?php echo htmlspecialchars($queryName); ?>">
                         <input type="hidden" id="visual_query_id_edit" name="visual_query_id_edit" value="<?php echo htmlspecialchars($queryId); ?>">
                         <input type="hidden" name="vquery"/>
                         <input type="hidden" name="visual_query_id_edit_submit" id="visual_query_id_edit_submit_field">

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -990,8 +990,8 @@ $('body').on('click', '#btnUpdateVisualQuery', function () {
     if (queryId) {
         // --- EXISTING QUERY: UPDATE IT ---
         // Get query name and data source from VQB page globals or fetch from server
-        var queryName = (typeof vqbQueryName !== 'undefined') ? vqbQueryName : '';
-        var dataSourceId = (typeof vqbDataSourceId !== 'undefined') ? vqbDataSourceId : '';
+        var queryName = $currentContext.closest('form').data('query-name');
+        var dataSourceId = $currentContext.closest('form').data('source-id');
 
         // Generate SQL first to populate the save modal
         $thisButton.prop('disabled', true).find('i').removeClass('fa-save').addClass('fa-spinner fa-spin');


### PR DESCRIPTION
When editing a saved visual query, the "Update Visual Query" button opens a save modal. This modal was not being pre-populated with the existing query's name and data source connection.

This change makes the application more user-friendly by ensuring this information is correctly pre-filled.

The fix involves:
1.  Adding `data-query-name` and `data-source-id` attributes to the VQB form element in the view, populated with the correct data from the controller.
2.  Updating the JavaScript click handler for the "Update" button to retrieve the query name and data source ID from these new data attributes, rather than relying on global JavaScript variables. This provides a more robust and reliable method for passing data from the server-side view to the client-side script.