### PR TITLE
Fix: Correctly save joined fields and pre-populate VQB update modal

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -2274,41 +2274,24 @@ function initializeVQBPage() {
 function populateVQBFormWithSavedData(savedParams) {
     console.log('Populating VQB form with saved data:', savedParams);
 
-    // Populate non-aggregated fields
-    if (savedParams.fields && Array.isArray(savedParams.fields)) {
-        setTimeout(function () {
-            $('select[name="fields[]"]').val(savedParams.fields).trigger('change');
-            console.log('Set fields to:', savedParams.fields);
-        }, 100);
-    }
-
-    // Populate joins
+    // First, populate the join rows. This is necessary to know which tables' fields to load.
     if (savedParams.jointype && Array.isArray(savedParams.jointype)) {
         savedParams.jointype.forEach(function (type, idx) {
             if (type && savedParams.jointable && savedParams.jointable[idx]) {
-                // Create join row
                 var $clone = $('#fieldCloneTable').clone().removeAttr('id').addClass('cloned-join-row');
                 $clone.find('select[name="jointype[]"]').val(type);
-
                 var $tableSelect = $clone.find('select[name="jointable[]"]');
                 if (allTablesOptionsHTML) {
                     $tableSelect.html(allTablesOptionsHTML);
                 }
                 $tableSelect.val(savedParams.jointable[idx]);
-
                 $('#btnJoinTable').after($clone);
                 $clone.show();
 
-                // Initialize Select2 on the new elements
                 $clone.find('select').each(function () {
-                    $(this).select2({
-                        placeholder: 'Choose',
-                        allowClear: true,
-                        minimumResultsForSearch: 0
-                    });
+                    $(this).select2({ placeholder: 'Choose', allowClear: true, minimumResultsForSearch: 0 });
                 });
 
-                // Populate join fields if available
                 if (savedParams.joinfield && savedParams.joinfield[idx]) {
                     populateJoinFieldDropdown(
                         $clone.find('select[name="joinfield[]"]'),
@@ -2317,126 +2300,111 @@ function populateVQBFormWithSavedData(savedParams) {
                         vqbDataSourceId
                     );
                 }
-
-                if (savedParams.joinfieldp && savedParams.joinfieldp[idx]) {
-                    setTimeout(function () {
-                        $clone.find('select[name="joinfieldp[]"]').val(savedParams.joinfieldp[idx]).trigger('change');
-                    }, 200);
-                }
             }
         });
     }
 
-    // Populate WHERE conditions
-    if (savedParams.fname && Array.isArray(savedParams.fname)) {
-        savedParams.fname.forEach(function (name, idx) {
-            if (name && savedParams.fvalue && savedParams.fvalue[idx]) {
-                var $clone = $('#fieldClone').clone().removeAttr('id');
-                $clone.find('select[name="fname[]"]').val(name);
-                $clone.find('input[name="fvalue[]"]').val(savedParams.fvalue[idx]);
+    // Now, call addTablesToDropdown to populate all field dropdowns with the correct options.
+    // The rest of the form population logic will happen in the callback.
+    addTablesToDropdown(vqbDataSourceId, function(success, fieldOptionsHtml) {
+        if (!success) {
+            $.jGrowl('Failed to load field options, form may not populate correctly.', { header: 'Error', theme: 'error' });
+            return;
+        }
 
-                if (idx > 0 && savedParams.ftype && savedParams.ftype[idx]) {
-                    $clone.find('select[name="ftype[]"]').val(savedParams.ftype[idx]);
-                }
+        // Populate non-aggregated fields
+        if (savedParams.fields && Array.isArray(savedParams.fields)) {
+            $('select[name="fields[]"]').val(savedParams.fields).trigger('change');
+        }
 
-                $('#btnAddWhere').after($clone);
+        // Re-set the primary table join fields now that their options are loaded
+        $('.cloned-join-row').each(function(idx) {
+            var $row = $(this);
+            if (savedParams.joinfieldp && savedParams.joinfieldp[idx]) {
+                $row.find('select[name="joinfieldp[]"]').val(savedParams.joinfieldp[idx]).trigger('change');
+            }
+        });
 
-                // Initialize Select2
-                $clone.find('select').each(function () {
-                    $(this).select2({
-                        placeholder: 'Choose',
-                        allowClear: true,
-                        minimumResultsForSearch: 0
+        // Populate WHERE conditions
+        if (savedParams.fname && Array.isArray(savedParams.fname)) {
+            savedParams.fname.forEach(function (name, idx) {
+                if (name && savedParams.fvalue && savedParams.fvalue[idx]) {
+                    var $clone = $('#fieldClone').clone().removeAttr('id');
+                    $clone.find('select[name="fname[]"]').val(name).end()
+                          .find('input[name="fvalue[]"]').val(savedParams.fvalue[idx]).end();
+                    if (idx > 0 && savedParams.ftype && savedParams.ftype[idx]) {
+                        $clone.find('select[name="ftype[]"]').val(savedParams.ftype[idx]);
+                    }
+                    $('#btnAddWhere').after($clone);
+                    $clone.find('select').each(function () {
+                        $(this).select2({ placeholder: 'Choose', allowClear: true, minimumResultsForSearch: 0 });
                     });
-                });
-
-                $clone.show();
-            }
-        });
-    }
-
-    // Populate aggregated fields
-    if (savedParams.agg_field && Array.isArray(savedParams.agg_field)) {
-        savedParams.agg_field.forEach(function (field, idx) {
-            if (field && savedParams.agg_func && savedParams.agg_func[idx]) {
-                var $clone = $('#fieldCloneAggregate').clone().removeAttr('id');
-                $clone.find('select[name="agg_field[]"]').val(field);
-                $clone.find('select[name="agg_func[]"]').val(savedParams.agg_func[idx]);
-
-                if (savedParams.agg_alias && savedParams.agg_alias[idx]) {
-                    $clone.find('input[name="agg_alias[]"]').val(savedParams.agg_alias[idx]);
+                    $clone.show();
                 }
+            });
+        }
 
-                $('#aggregateFieldsContainer').append($clone);
-
-                // Initialize Select2
-                $clone.find('select').each(function () {
-                    $(this).select2({
-                        placeholder: 'Choose',
-                        allowClear: true,
-                        minimumResultsForSearch: 0
+        // Populate aggregated fields
+        if (savedParams.agg_field && Array.isArray(savedParams.agg_field)) {
+            savedParams.agg_field.forEach(function (field, idx) {
+                if (field && savedParams.agg_func && savedParams.agg_func[idx]) {
+                    var $clone = $('#fieldCloneAggregate').clone().removeAttr('id');
+                    $clone.find('select[name="agg_field[]"]').val(field).end()
+                          .find('select[name="agg_func[]"]').val(savedParams.agg_func[idx]).end()
+                          .find('input[name="agg_alias[]"]').val(savedParams.agg_alias[idx] || '').end();
+                    $('#aggregateFieldsContainer').append($clone);
+                    $clone.find('select').each(function () {
+                        $(this).select2({ placeholder: 'Choose', allowClear: true, minimumResultsForSearch: 0 });
                     });
-                });
+                    $clone.show();
+                }
+            });
+        }
 
-                $clone.show();
-            }
-        });
-    }
-
-    // Populate ORDER BY
-    if (savedParams.orderfields && Array.isArray(savedParams.orderfields) && savedParams.orderfields.length > 0) {
-        setTimeout(function () {
+        // Populate ORDER BY
+        if (savedParams.orderfields && Array.isArray(savedParams.orderfields) && savedParams.orderfields.length > 0) {
             $('select[name="orderfields[]"]').val(savedParams.orderfields).trigger('change');
             $('#orderby').show();
-
             if (savedParams.chkDescending === 'on' || savedParams.chkDescending === true) {
                 $('input[name="chkDescending"]').prop('checked', true);
             }
-        }, 150);
-    }
+        }
 
-    // Populate GROUP BY
-    if (savedParams.groupfields && Array.isArray(savedParams.groupfields) && savedParams.groupfields.length > 0) {
-        setTimeout(function () {
+        // Populate GROUP BY
+        if (savedParams.groupfields && Array.isArray(savedParams.groupfields) && savedParams.groupfields.length > 0) {
             $('select[name="groupfields[]"]').val(savedParams.groupfields).trigger('change');
             $('#group').show();
-        }, 150);
-    }
+        }
 
-    // Populate LIMIT
-    if (savedParams.limitStart || savedParams.limitNumRows) {
-        $('input[name="limitStart"]').val(savedParams.limitStart || '');
-        $('input[name="limitNumRows"]').val(savedParams.limitNumRows || '');
-        $('#limit').show();
-    }
+        // Populate LIMIT
+        if (savedParams.limitStart || savedParams.limitNumRows) {
+            $('input[name="limitStart"]').val(savedParams.limitStart || '');
+            $('input[name="limitNumRows"]').val(savedParams.limitNumRows || '');
+            $('#limit').show();
+        }
 
-    // Populate HAVING conditions
-    if (savedParams.hfname && Array.isArray(savedParams.hfname)) {
-        savedParams.hfname.forEach(function (name, idx) {
-            if (name && savedParams.hfvalue && savedParams.hfvalue[idx]) {
-                var $clone = $('#fieldCloneHaving').clone().removeAttr('id');
-                $clone.find('select[name="hfname[]"]').val(name);
-                $clone.find('input[name="hfvalue[]"]').val(savedParams.hfvalue[idx]);
-
-                if (idx > 0 && savedParams.htype && savedParams.htype[idx]) {
-                    $clone.find('select[name="htype[]"]').val(savedParams.htype[idx]);
-                }
-
-                $('#havingConditionsContainer').append($clone);
-
-                // Initialize Select2
-                $clone.find('select').each(function () {
-                    $(this).select2({
-                        placeholder: 'Choose',
-                        allowClear: true,
-                        minimumResultsForSearch: 0
-                    });
+        // Populate HAVING conditions (after aggregates are populated)
+        if (savedParams.hfname && Array.isArray(savedParams.hfname)) {
+            updateHavingFieldNameOptions(); // Ensure options are fresh
+            setTimeout(function() { // Use a timeout to allow dropdowns to render
+                savedParams.hfname.forEach(function (name, idx) {
+                    if (name && savedParams.hfvalue && savedParams.hfvalue[idx]) {
+                        var $clone = $('#fieldCloneHaving').clone().removeAttr('id');
+                        $clone.find('select[name="hfname[]"]').val(name).end()
+                              .find('input[name="hfvalue[]"]').val(savedParams.hfvalue[idx]).end();
+                        if (idx > 0 && savedParams.htype && savedParams.htype[idx]) {
+                            $clone.find('select[name="htype[]"]').val(savedParams.htype[idx]);
+                        }
+                        $('#havingConditionsContainer').append($clone);
+                        $clone.find('select').each(function () {
+                             $(this).select2({ placeholder: 'Choose', allowClear: true, minimumResultsForSearch: 0 });
+                        });
+                        $clone.show();
+                    }
                 });
+            }, 100);
+        }
 
-                $clone.show();
-            }
-        });
-    }
-
-    console.log('VQB form population completed');
+        console.log('VQB form population completed.');
+    });
 }


### PR DESCRIPTION
This commit addresses two issues in the Visual Query Builder (VQB):

1.  When updating a saved visual query, the modal was not pre-populated with the query's name and connection info. This has been fixed by passing the necessary data in `data-*` attributes on the form and having the JavaScript read from there, making it more robust.

2.  When editing a saved query with joined tables, fields selected from those joined tables were not being correctly re-selected on page load. This caused them to be dropped from the query on subsequent saves. This was due to a race condition where the script tried to select the fields before the dropdown was populated with the options from the joined tables. The form population logic has been refactored to ensure all field options are loaded before their values are set, resolving the issue.